### PR TITLE
Options fix

### DIFF
--- a/HCDevice.py
+++ b/HCDevice.py
@@ -122,7 +122,7 @@ class HCDevice:
             for option in data["options"]:
                 option_uid = option["uid"]
                 if str(option_uid) not in self.features:
-                     raise ValueError(
+                    raise ValueError(
                         f"Unable to configure appliance. Option UID {option_uid} is not"
                         " valid for this device."
                     )

--- a/HCDevice.py
+++ b/HCDevice.py
@@ -119,10 +119,11 @@ class HCDevice:
             )
 
         if "options" in data:
-            for option_uid in data["options"]:
+            for option in data["options"]:
+                option_uid = option["uid"]
                 if str(option_uid) not in self.features:
-                    raise ValueError(
-                        f"Unable to configure appliance. Option UID {uid} is not"
+                     raise ValueError(
+                        f"Unable to configure appliance. Option UID {option_uid} is not"
                         " valid for this device."
                     )
 


### PR DESCRIPTION
Made a mistake in the options checking code - it was trying to look for `{"uid":blah,"value":blah}` instead of the UID value. 