### PR TITLE
Use a copy of topics

### DIFF
--- a/hc2mqtt
+++ b/hc2mqtt
@@ -116,7 +116,7 @@ def client_connect(client, device, mqtt_topic):
             print(now(), device_name, "ERROR", e, file=sys.stderr)
 
     host = device["host"]
-    device_topics = topics
+    device_topics = topics.copy()
     active_program = False
 
     for value in device["features"]:


### PR DESCRIPTION
The way `device_topics` was assigned `topics`  in each device thread meant that it expanded to include all the topics from all devices so would show  invalid null values. This uses a copy to prevent this. 

Before:

```
{
    "Error": null,
    "AllowBackendConnection": true,
    "PowerState": "Off",
    "BackendConnected": true,
    "CustomerServiceConnectionAllowed": null,
    "DoorState": null,
    "SoftwareUpdateTransactionID": null,
    "WiFiSignalStrength": 194,
    "AssistantForceFridge": null,
    "AssistantFridge": null,
    "SetpointTemperature": null,
    "SuperMode": null,
    "Refrigerator": null,
    "ApplianceDateTime": null,
    "Functionality": null,
    "Name": null,
    "Program": null,
    "Language": null,
    "RemoteControlLevel": null,
    "SynchronizeWithTimeServer": null,
    "DisplayMode": null,
    "TimeFormat": null,
    "Timezone": null,
    "ErrorCodesList": null,
    "Handling": null,
    "InteriorIlluminationActive": null,
    "OperationState": "Inactive",
    "Started": null,
    "RemoteControlActive": true,
    "RemoteControlStartAllowed": true,
    "BrandLogo": null,
    "DoorOpeningAndDryingAssistantChildLock": null,
    "DryingAssistantAllPrograms": null,
    "EcoAsDefault": null,
    "EcoPrognosis": null,
    "ExtraDry": null,
    "HotWater": null,
    "InteriorLight": null,
    "InteriorLightMode": null,
    "Cleaning": null,
    "Drying": null,
    "Duration": null,
    "RinseAid": null,
    "SensitivityTurbidity": null,
    "SilenceOnDemandDefaultTime": null,
    "SoundLevelKey": null,
    "SoundLevelSignal": null,
    "SpeedOnDemand": null,
    "TimeLight": null,
    "WaterHardness": null,
    "EcoDryActive": null,
    "CleaningLevel": null,
    "DryingLevel": null,
    "DurationLevel": null,
    "Phase": null,
    "CalculationFinished": null,
    "CleaningCannotBeImproved": null,
    "DryingCannotBeImproved": null,
    "SpeedCannotBeImproved": null,
    "ProgramPhase": null,
    "SilenceOnDemandRemainingTime": null,
    "AllowConsumerInsights": false,
    "AmbientLightBrightness": null,
    "AmbientLightColor": "CustomColor",
    "AmbientLightCustomColor": "#ffbe64",
    "AmbientLightEnabled": true,
    "LocalControlActive": false,
    "ButtonTones": true,
    "Lighting": false,
    "LightingBrightness": 10,
    "CarbonFilterType": "None",
    "DelayedShutOffStage": "FanStage01",
    "DelayedShutOffTime": 300,
    "IntervalStage": "FanStage01",
    "IntervalTimeOff": 3300,
    "IntervalTimeOn": 300,
    "NoiseReduction": false,
    "SensorSensitivity": 3,
    "CarbonFilterSaturation": null,
    "GreaseFilterSaturation": 31,
    "RegenerativeCarbonFilterLifeCycle": null,
    "RegenerativeCarbonFilterSaturation": null
}
```

After:
```
{
    "Error": null,
    "AllowBackendConnection": true,
    "AllowConsumerInsights": false,
    "AmbientLightBrightness": null,
    "AmbientLightColor": "CustomColor",
    "AmbientLightCustomColor": "#ffbe64",
    "AmbientLightEnabled": false,
    "PowerState": "Off",
    "BackendConnected": true,
    "LocalControlActive": false,
    "OperationState": "Inactive",
    "RemoteControlActive": true,
    "RemoteControlStartAllowed": true,
    "SoftwareUpdateTransactionID": null,
    "WiFiSignalStrength": 195,
    "ButtonTones": true,
    "Lighting": false,
    "LightingBrightness": 10,
    "CarbonFilterType": "None",
    "DelayedShutOffStage": "FanStage01",
    "DelayedShutOffTime": 300,
    "IntervalStage": "FanStage01",
    "IntervalTimeOff": 3300,
    "IntervalTimeOn": 300,
    "NoiseReduction": false,
    "SensorSensitivity": 3,
    "CarbonFilterSaturation": null,
    "GreaseFilterSaturation": 31,
    "RegenerativeCarbonFilterLifeCycle": null,
    "RegenerativeCarbonFilterSaturation": null
}
```