### PR TITLE
[hc2mqtt.py] Click: allow values from Environment Variables

### DIFF
--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -200,4 +200,4 @@ def client_connect(client, device, mqtt_topic):
 
 
 if __name__ == "__main__":
-    hc2mqtt()
+    hc2mqtt(auto_envvar_prefix="HCPY")


### PR DESCRIPTION
This change is necessary to pass environment variables in the Docker container to the script.
The environment variables must begin with "HCPY_".
Each command and parameter is then added as an uppercase underscore-separated variable.
e.g. --mqtt-username becomes HCPY_MQTT_USERNAME