### PR TITLE
Add debug options

### DIFF
--- a/HCDevice.py
+++ b/HCDevice.py
@@ -259,15 +259,13 @@ class HCDevice:
             if isinstance(data, list) is False:
                 data = [data]
 
-            if action == "POST":
+            if action == "POST" and self.debug is False:
                 if resource == "/ro/values":
                     # Raises exceptions on failure
-                    if self.debug is False:
-                        self.test_feature(data)
+                    self.test_feature(data)
                 elif resource == "/ro/activeProgram":
                     # Raises exception on failure
-                    if self.debug is False:
-                        self.test_program_data(data)
+                    self.test_program_data(data)
 
             msg["data"] = data
 

--- a/HCDevice.py
+++ b/HCDevice.py
@@ -57,7 +57,7 @@ def now():
 
 
 class HCDevice:
-    def __init__(self, ws, device):
+    def __init__(self, ws, device, debug=False):
         self.ws = ws
         self.features_lock = threading.Lock()
         self.features = device.get("features")
@@ -66,7 +66,7 @@ class HCDevice:
         self.tx_msg_id = None
         self.device_name = "hcpy"
         self.device_id = "0badcafe"
-        self.debug = False
+        self.debug = debug
         self.services_initialized = False
         self.services = {}
         self.token = None
@@ -262,14 +262,18 @@ class HCDevice:
             if action == "POST":
                 if resource == "/ro/values":
                     # Raises exceptions on failure
-                    self.test_feature(data)
+                    if self.debug is False:
+                        self.test_feature(data)
                 elif resource == "/ro/activeProgram":
                     # Raises exception on failure
-                    self.test_program_data(data)
+                    if self.debug is False:
+                        self.test_program_data(data)
 
             msg["data"] = data
 
         try:
+            if self.debug:
+                self.print(f"TX: {msg}")
             self.ws.send(msg)
         except Exception as e:
             print(self.name, "Failed to send", e, msg, traceback.format_exc())

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -27,6 +27,7 @@ from HCSocket import HCSocket, now
 @click.option("--mqtt_certfile")
 @click.option("--mqtt_keyfile")
 @click.option("--mqtt_clientname", default="hcpy1")
+@click.option("--debug/--no-debug", default=False)
 @click_config_file.configuration_option()
 def hc2mqtt(
     devices_file: str,
@@ -40,6 +41,7 @@ def hc2mqtt(
     mqtt_certfile: str,
     mqtt_keyfile: str,
     mqtt_clientname: str,
+    debug: bool
 ):
 
     def on_connect(client, userdata, flags, rc):
@@ -101,6 +103,7 @@ def hc2mqtt(
         f"Hello {devices_file=} {mqtt_host=} {mqtt_prefix=} "
         f"{mqtt_port=} {mqtt_username=} {mqtt_password=} "
         f"{mqtt_ssl=} {mqtt_cafile=} {mqtt_certfile=} {mqtt_keyfile=} {mqtt_clientname=}"
+        f"{debug=}"
     )
 
     with open(devices_file, "r") as f:
@@ -130,7 +133,7 @@ def hc2mqtt(
 
     for device in devices:
         mqtt_topic = mqtt_prefix + device["name"]
-        thread = Thread(target=client_connect, args=(client, device, mqtt_topic))
+        thread = Thread(target=client_connect, args=(client, device, mqtt_topic, debug))
         thread.start()
 
     client.loop_forever()
@@ -140,7 +143,7 @@ global dev
 dev = {}
 
 
-def client_connect(client, device, mqtt_topic):
+def client_connect(client, device, mqtt_topic, debug):
     host = device["host"]
     name = device["name"]
 
@@ -193,7 +196,7 @@ def client_connect(client, device, mqtt_topic):
         try:
             print(now(), name, f"connecting to {host}")
             ws = HCSocket(host, device["key"], device.get("iv", None))
-            dev[name] = HCDevice(ws, device)
+            dev[name] = HCDevice(ws, device, debug)
             dev[name].run_forever(on_message=on_message, on_open=on_open, on_close=on_close)
         except Exception as e:
             print(now(), device["name"], "ERROR", e, file=sys.stderr)

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -27,6 +27,7 @@ options:
   HCPY_MQTT_CERTFILE: ""
   HCPY_MQTT_KEYFILE: ""
   HCPY_MQTT_CLIENTNAME: "hcpy1"
+  HCPY_DEBUG: false
 schema:
   HCPY_DEVICES_FILE: str
   HCPY_MQTT_HOST: str
@@ -39,4 +40,5 @@ schema:
   HCPY_MQTT_CERTFILE: str
   HCPY_MQTT_KEYFILE: str
   HCPY_MQTT_CLIENTNAME: str
+  HCPY_DEBUG: bool?
 startup: services


### PR DESCRIPTION
Exposes some debug options, will print all websocket messages to the log and skips any checking when POSTing messages to the device.