### PR TITLE
Add domain_suffix option

### DIFF
--- a/HCSocket.py
+++ b/HCSocket.py
@@ -37,8 +37,11 @@ sslpsk.sslpsk._sslobj = _sslobj
 
 
 class HCSocket:
-    def __init__(self, host, psk64, iv64=None):
+    def __init__(self, host, psk64, iv64=None, domain_suffix=""):
         self.host = host
+        if domain_suffix:
+            self.host = f"{host}.{domain_suffix}"
+
         self.psk = base64url(psk64 + "===")
         self.debug = False
 
@@ -49,11 +52,11 @@ class HCSocket:
             self.enckey = hmac(self.psk, b"ENC")
             self.mackey = hmac(self.psk, b"MAC")
             self.port = 80
-            self.uri = "ws://" + host + ":80/homeconnect"
+            self.uri = f"ws://{host}:80/homeconnect"
         else:
             self.http = False
             self.port = 443
-            self.uri = "wss://" + host + ":443/homeconnect"
+            self.uri = f"wss://{host}:443/homeconnect"
 
         # don't connect automatically so that debug etc can be set
         # self.reconnect()

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -27,6 +27,7 @@ from HCSocket import HCSocket, now
 @click.option("--mqtt_certfile")
 @click.option("--mqtt_keyfile")
 @click.option("--mqtt_clientname", default="hcpy1")
+@click.option("--domain_suffix", default="")
 @click_config_file.configuration_option()
 def hc2mqtt(
     devices_file: str,
@@ -40,6 +41,7 @@ def hc2mqtt(
     mqtt_certfile: str,
     mqtt_keyfile: str,
     mqtt_clientname: str,
+    domain_suffix: str
 ):
 
     def on_connect(client, userdata, flags, rc):
@@ -101,6 +103,7 @@ def hc2mqtt(
         f"Hello {devices_file=} {mqtt_host=} {mqtt_prefix=} "
         f"{mqtt_port=} {mqtt_username=} {mqtt_password=} "
         f"{mqtt_ssl=} {mqtt_cafile=} {mqtt_certfile=} {mqtt_keyfile=} {mqtt_clientname=}"
+        f"{domain_suffix=}"
     )
 
     with open(devices_file, "r") as f:
@@ -130,7 +133,7 @@ def hc2mqtt(
 
     for device in devices:
         mqtt_topic = mqtt_prefix + device["name"]
-        thread = Thread(target=client_connect, args=(client, device, mqtt_topic))
+        thread = Thread(target=client_connect, args=(client, device, mqtt_topic, domain_suffix))
         thread.start()
 
     client.loop_forever()
@@ -140,7 +143,7 @@ global dev
 dev = {}
 
 
-def client_connect(client, device, mqtt_topic):
+def client_connect(client, device, mqtt_topic, domain_suffix):
     host = device["host"]
     name = device["name"]
 
@@ -192,7 +195,7 @@ def client_connect(client, device, mqtt_topic):
         time.sleep(3)
         try:
             print(now(), name, f"connecting to {host}")
-            ws = HCSocket(host, device["key"], device.get("iv", None))
+            ws = HCSocket(host, device["key"], device.get("iv", None), domain_suffix)
             dev[name] = HCDevice(ws, device)
             dev[name].run_forever(on_message=on_message, on_open=on_open, on_close=on_close)
         except Exception as e:

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "HomeConnect2MQTT"
 description: "Run HCPY as addon"
-version: "v0.1.0"
+version: "v0.1.1"
 slug: "hcpy"
 image: ghcr.io/hcpy2-0/hcpy
 init: false

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -27,6 +27,7 @@ options:
   HCPY_MQTT_CERTFILE: ""
   HCPY_MQTT_KEYFILE: ""
   HCPY_MQTT_CLIENTNAME: "hcpy1"
+  HCPY_DOMAIN_SUFFIX: ""
 schema:
   HCPY_DEVICES_FILE: str
   HCPY_MQTT_HOST: str
@@ -39,4 +40,5 @@ schema:
   HCPY_MQTT_CERTFILE: str
   HCPY_MQTT_KEYFILE: str
   HCPY_MQTT_CLIENTNAME: str
+  HCPY_DOMAIN_SUFFIX: str
 startup: services


### PR DESCRIPTION
Resolves https://github.com/hcpy2-0/hcpy/issues/55


Provides the `domain_suffix` option, which allows users to specify their local DNS domain suffix. This helps where HA addons specify their own local search domain preventing resolution of local devices. 