### PR TITLE
New feature: selecting program

### DIFF
--- a/HCDevice.py
+++ b/HCDevice.py
@@ -266,6 +266,9 @@ class HCDevice:
                 elif resource == "/ro/activeProgram":
                     # Raises exception on failure
                     self.test_program_data(data)
+                elif resource == "/ro/selectedProgram":
+                    # Raises exception on failure
+                    self.test_program_data(data)
 
             msg["data"] = data
 

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -67,8 +67,12 @@ def hc2mqtt(
                     # If the device has the SelectedProgram feature it allows programs to be selected
                     # via /ro/selectedProgram
                     if "BSH.Common.Root.SelectedProgram" == device["features"][value]["name"]:
-                        mqtt_selected_program_topic = f"{mqtt_prefix}{device['name']}/selectedProgram"
-                        print(now(), device["name"], f"program topic: {mqtt_selected_program_topic}")
+                        mqtt_selected_program_topic = (
+                            f"{mqtt_prefix}{device['name']}/selectedProgram"
+                        )
+                        print(
+                            now(), device["name"], f"program topic: {mqtt_selected_program_topic}"
+                        )
                         client.subscribe(mqtt_selected_program_topic)
         else:
             print(now(), f"ERROR MQTT connection failed: {rc}")

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -64,6 +64,12 @@ def hc2mqtt(
                         mqtt_active_program_topic = f"{mqtt_prefix}{device['name']}/activeProgram"
                         print(now(), device["name"], f"program topic: {mqtt_active_program_topic}")
                         client.subscribe(mqtt_active_program_topic)
+                    # If the device has the SelectedProgram feature it allows programs to be selected
+                    # via /ro/selectedProgram
+                    if "BSH.Common.Root.SelectedProgram" == device["features"][value]["name"]:
+                        mqtt_selected_program_topic = f"{mqtt_prefix}{device['name']}/selectedProgram"
+                        print(now(), device["name"], f"program topic: {mqtt_selected_program_topic}")
+                        client.subscribe(mqtt_selected_program_topic)
         else:
             print(now(), f"ERROR MQTT connection failed: {rc}")
 
@@ -91,6 +97,8 @@ def hc2mqtt(
                 resource = "/ro/values"
             elif topic == "activeProgram":
                 resource = "/ro/activeProgram"
+            elif topic == "selectedProgram":
+                resource = "/ro/selectedProgram"
             else:
                 raise Exception(f"Payload topic {topic} is unknown.")
 


### PR DESCRIPTION
Proof of concept for how to change currently active program.

Listens /{prefix}/{devicename}/selectedProgram
JSON format
`{"program":8196}`

This uses same test_program_data() as activeProgram although I don't think options can be used with selecting program.

Fixes #82 