### PR TITLE
Add Home Assistant MQTT autodiscovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
   apt-get remove -y gcc python3-dev libssl-dev && \
   apt-get autoremove -y
 
-COPY hc2mqtt.py hc-login.py HCDevice.py HCSocket.py HCxml2json.py run.sh ./
+COPY hc2mqtt.py hc-login.py HADiscovery.py HCDevice.py HCSocket.py HCxml2json.py run.sh ./
 
 RUN chmod a+x ./run.sh
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -41,14 +41,14 @@ MAGIC_OVERRIDES = {
             "payload_on": "Present"
         }
     },
-    523: {  # BSH.Common.Status.RemoteControlActive
+    517: {  # BSH.Common.Status.RemoteControlStartAllowed
         "component_type": "binary_sensor",
         "payload_values": {
             "payload_on": True,
             "payload_off": False
         }
     },
-    524: {  # BSH.Common.Status.RemoteControlStartAllowed
+    523: {  # BSH.Common.Status.RemoteControlActive
         "component_type": "binary_sensor",
         "payload_values": {
             "payload_on": True,

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -202,9 +202,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
             or feature_type == "Option"
         ):
 
-            default_component_type = (
-                "binary_sensor" if feature_type == "Event" else "sensor"
-            )  # TODO use more appropriate types
+            default_component_type = "binary_sensor" if feature_type == "Event" else "sensor"
 
             overrides = feature.get("discovery", {})
 
@@ -222,6 +220,11 @@ def publish_ha_discovery(device, client, mqtt_topic):
                 "device": device_info,
                 "state_topic": f"{mqtt_topic}/state",
                 # "availability_topic": f"{mqtt_topic}/LWT",
+                # # I found the behaviour of `availability_topic` unsatisfactory -
+                # # since it would set all device attributes to "unavailable"
+                # # then back to their correct values on every disconnect/
+                # # reconnect. This leaves a lot of noise in the HA history, so
+                # # I felt things were better off without an `availability_topic`.
                 "value_template": "{{value_json." + name + " | default('unavailable')}}",
                 "object_id": f"{device_ident}_{name}",
                 "unique_id": f"{device_ident}_{name}",

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -13,7 +13,10 @@ HA_DISCOVERY_PREFIX = "homeassistant"
 
 
 def publish_ha_states(state, client, mqtt_topic):
-    pass
+    for key, value in state.items():
+        state_topic = f"{mqtt_topic}/{key}"
+        print(f"{now()} Publishing state for {key} at {state_topic}")
+        client.publish(state_topic, json.dumps(value))
 
 
 def publish_ha_discovery(device, client, mqtt_topic):
@@ -45,12 +48,12 @@ def publish_ha_discovery(device, client, mqtt_topic):
         if available and (access == "read" or access == "readWrite"):
             name_parts = feature["name"].split(".")
             name = name_parts[-1]
-            feature_type = name_parts[-2]
+            # feature_type = name_parts[-2]
 
             component_type = "sensor" # TODO use appropriate types
 
             discovery_topic = f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
-            state_topic = f"{mqtt_topic}/{feature_type}/{name}"
+            state_topic = f"{mqtt_topic}/{name}"
             # print(discovery_topic, state_topic)
 
             discovery_payload = json.dumps({
@@ -63,4 +66,4 @@ def publish_ha_discovery(device, client, mqtt_topic):
             print(discovery_topic)
             # print(discovery_payload)
 
-            client.publish(discovery_topic, discovery_payload, retain=False) # TODO make retain=True when stable
+            client.publish(discovery_topic, discovery_payload, retain=True)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -5,7 +5,7 @@ from HCSocket import now
 
 
 def decamelcase(str):
-    split = re.findall(r'[A-Z](?:[a-z]+|[A-Z]*(?=[A-Z]|$))', str)
+    split = re.findall(r"[A-Z](?:[a-z]+|[A-Z]*(?=[A-Z]|$))", str)
     return f"{split[0]} {' '.join(split[1:]).lower()}".strip()
 
 
@@ -21,39 +21,27 @@ HA_DISCOVERY_PREFIX = "homeassistant"
 MAGIC_OVERRIDES = {
     3: {  # BSH.Common.Setting.AllowBackendConnection
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     5: {  # BSH.Common.Status.BackendConnected
         "component_type": "binary_sensor",
         "payload_values": {
             "device_class": "connectivity",
             "payload_on": True,
-            "payload_off": False
-        }
+            "payload_off": False,
+        },
     },
     21: {  # BSH.Common.Event.SoftwareUpdateAvailable
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "update",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "update", "payload_on": "Present"},
     },
     517: {  # BSH.Common.Status.RemoteControlStartAllowed
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     523: {  # BSH.Common.Status.RemoteControlActive
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     524: {  # BSH.Common.Setting.ChildLock
         "component_type": "binary_sensor",
@@ -61,183 +49,104 @@ MAGIC_OVERRIDES = {
             "device_class": "lock",
             "payload_on": False,  # Lock "on" means "unlocked" to HA
             "payload_off": True,  # Lock "off" means "locked"
-        }
+        },
     },
     525: {  # BSH.Common.Event.AquaStopOccured
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     527: {  # BSH.Common.Status.DoorState
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "door",
-            "payload_on": "Open",
-            "payload_off": "Closed"
-        }
+        "payload_values": {"device_class": "door", "payload_on": "Open", "payload_off": "Closed"},
     },
     539: {  # BSH.Common.Setting.PowerState
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "power"
-        }
+        "payload_values": {"device_class": "power"},
     },
-    542: {  # BSH.Common.Option.ProgramProgress
-        "payload_values": {
-            "unit_of_measurement": "%"
-        }
-    },
+    542: {"payload_values": {"unit_of_measurement": "%"}},  # BSH.Common.Option.ProgramProgress
     543: {  # BSH.Common.Event.LowWaterPressure
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     544: {  # BSH.Common.Option.RemainingProgramTime
-        "payload_values": {
-            "unit_of_measurement": "s",
-            "device_class": "duration"
-        }
+        "payload_values": {"unit_of_measurement": "s", "device_class": "duration"}
     },
     549: {  # BSH.Common.Option.RemainingProgramTimeIsEstimated
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     558: {  # BSH.Common.Option.StartInRelative
-        "payload_values": {
-            "unit_of_measurement": "s",
-            "device_class": "duration"
-        }
+        "payload_values": {"unit_of_measurement": "s", "device_class": "duration"}
     },
     4101: {  # Dishcare.Dishwasher.Status.SilenceOnDemandRemainingTime
-        "payload_values": {
-            "unit_of_measurement": "s",
-            "device_class": "duration"
-        }
+        "payload_values": {"unit_of_measurement": "s", "device_class": "duration"}
     },
     4103: {  # Dishcare.Dishwasher.Status.EcoDryActive
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     4382: {  # Dishcare.Dishwasher.Status.SilenceOnDemandDefaultTime
-        "payload_values": {
-            "unit_of_measurement": "s",
-            "device_class": "duration"
-        }
+        "payload_values": {"unit_of_measurement": "s", "device_class": "duration"}
     },
     4384: {  # Dishcare.Dishwasher.Setting.SpeedOnDemand
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     4608: {  # Dishcare.Dishwasher.Event.InternalError
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4609: {  # Dishcare.Dishwasher.Event.CheckFilterSystem
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4610: {  # Dishcare.Dishwasher.Event.DrainingNotPossible
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4611: {  # Dishcare.Dishwasher.Event.DrainPumpBlocked
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4612: {  # Dishcare.Dishwasher.Event.WaterheaterCalcified
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4613: {  # Dishcare.Dishwasher.Event.LowVoltage
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4624: {  # Dishcare.Dishwasher.Event.SaltLack
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4625: {  # Dishcare.Dishwasher.Event.RinseAidLack
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4626: {  # Dishcare.Dishwasher.Event.SaltNearlyEmpty
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     4627: {  # Dishcare.Dishwasher.Event.RinseAidNearlyEmpty
         "component_type": "binary_sensor",
-        "payload_values": {
-            "device_class": "problem",
-            "payload_on": "Present"
-        }
+        "payload_values": {"device_class": "problem", "payload_on": "Present"},
     },
     5121: {  # Dishcare.Dishwasher.Option.ExtraDry
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     5124: {  # Dishcare.Dishwasher.Option.HalfLoad
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     5127: {  # Dishcare.Dishwasher.Option.VarioSpeedPlus
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
     5136: {  # Dishcare.Dishwasher.Option.SilenceOnDemand
         "component_type": "binary_sensor",
-        "payload_values": {
-            "payload_on": True,
-            "payload_off": False
-        }
+        "payload_values": {"payload_on": True, "payload_off": False},
     },
 }
 
@@ -259,11 +168,8 @@ def publish_ha_discovery(device, client, mqtt_topic):
     device_description = device.get("description", {})
 
     version_parts = filter(
-        lambda d : d is not None,
-        [
-            device_description.get("version"),
-            device_description.get("revision")
-        ]
+        lambda d: d is not None,
+        [device_description.get("version"), device_description.get("revision")],
     )
 
     device_info = {
@@ -271,7 +177,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
         "name": device_name,
         "manufacturer": device_description.get("brand"),
         "model": device_description.get("model"),
-        "sw_version": ".".join(version_parts)
+        "sw_version": ".".join(version_parts),
     }
 
     for feature in device["features"].values():
@@ -281,12 +187,24 @@ def publish_ha_discovery(device, client, mqtt_topic):
         access = feature.get("access", "none")
         available = feature.get("available", False)
 
-        if (feature_type == "Setting" and available and (access == "read" or access == "readWrite")) or \
-            (feature_type == "Status" and available and (access == "read" or access == "readWrite")) or \
-            feature_type == "Event" or \
-            feature_type == "Option":
+        if (
+            (
+                feature_type == "Setting"
+                and available
+                and (access == "read" or access == "readWrite")
+            )
+            or (
+                feature_type == "Status"
+                and available
+                and (access == "read" or access == "readWrite")
+            )
+            or feature_type == "Event"
+            or feature_type == "Option"
+        ):
 
-            default_component_type = "binary_sensor" if feature_type == "Event" else "sensor" # TODO use more appropriate types
+            default_component_type = (
+                "binary_sensor" if feature_type == "Event" else "sensor"
+            )  # TODO use more appropriate types
 
             overrides = feature.get("discovery", {})
 
@@ -294,7 +212,9 @@ def publish_ha_discovery(device, client, mqtt_topic):
 
             extra_payload_values = overrides.get("payload_values", {})
 
-            discovery_topic = f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
+            discovery_topic = (
+                f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
+            )
             # print(discovery_topic, state_topic)
 
             discovery_payload = {
@@ -305,7 +225,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
                 "value_template": "{{value_json." + name + " | default('unavailable')}}",
                 "object_id": f"{device_ident}_{name}",
                 "unique_id": f"{device_ident}_{name}",
-                **extra_payload_values
+                **extra_payload_values,
             }
 
             if component_type == "binary_sensor":

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -1,0 +1,66 @@
+import json
+import re
+
+from HCSocket import now
+
+
+def decamelcase(str):
+    split = re.findall(r'[A-Z](?:[a-z]+|[A-Z]*(?=[A-Z]|$))', str)
+    return f"{split[0]} {' '.join(split[1:]).lower()}".strip()
+
+
+HA_DISCOVERY_PREFIX = "homeassistant"
+
+
+def publish_ha_states(state, client, mqtt_topic):
+    pass
+
+
+def publish_ha_discovery(device, client, mqtt_topic):
+    print(f"{now()} Publishing HA discovery for {device}")
+
+    device_ident = device["host"]
+    device_name = device["name"]
+    device_description = device.get("description", {})
+
+    version_parts = filter(
+        lambda d : d is not None,
+        [
+            device_description.get("version"),
+            device_description.get("revision")
+        ]
+    )
+
+    device_info = {
+        "identifiers": [device_ident],
+        "name": device_name,
+        "manufacturer": device_description.get("brand"),
+        "model": device_description.get("model"),
+        "sw_version": ".".join(version_parts)
+    }
+
+    for feature in device["features"].values():
+        access = feature.get("access", "none")
+        available = feature.get("available", False)
+        if available and (access == "read" or access == "readWrite"):
+            name_parts = feature["name"].split(".")
+            name = name_parts[-1]
+            feature_type = name_parts[-2]
+
+            component_type = "sensor" # TODO use appropriate types
+
+            discovery_topic = f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
+            state_topic = f"{mqtt_topic}/{feature_type}/{name}"
+            # print(discovery_topic, state_topic)
+
+            discovery_payload = json.dumps({
+                "name": decamelcase(name),
+                "device": device_info,
+                "state_topic": state_topic,
+                "object_id": f"{device_ident}_{name}",
+                "unique_id": f"{device_ident}_{name}",
+            })
+            print(discovery_topic)
+            # print(discovery_payload)
+
+            client.publish(discovery_topic, discovery_payload, retain=False) # TODO make retain=True when stable

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -12,6 +12,74 @@ def decamelcase(str):
 HA_DISCOVERY_PREFIX = "homeassistant"
 
 
+MAGIC_OVERRIDES = {
+    "BackendConnected": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "connectivity",
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    "SoftwareUpdateAvailable": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "update",
+            "payload_on": "Present"
+        }
+    },
+    "DoorState": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "door",
+            "payload_on": "Open",
+            "payload_off": "Closed"
+        }
+    },
+    "PowerState": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "power"
+        }
+    },
+    "RinseAidLack": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    "SaltLack": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    "RinseAidNearlyEmpty": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    "SaltNearlyEmpty": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    "WaterheaterCalcified": {
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+}
+
+
 def publish_ha_discovery(device, client, mqtt_topic):
     print(f"{now()} Publishing HA discovery for {device}")
 
@@ -43,10 +111,17 @@ def publish_ha_discovery(device, client, mqtt_topic):
         available = feature.get("available", False)
 
         if (feature_type == "Setting" and available and (access == "read" or access == "readWrite")) or \
+            (feature_type == "Status" and available and (access == "read" or access == "readWrite")) or \
             feature_type == "Event" or \
             feature_type == "Option":
 
-            component_type = "binary_sensor" if feature_type == "Event" else "sensor" # TODO use more appropriate types
+            default_component_type = "binary_sensor" if feature_type == "Event" else "sensor" # TODO use more appropriate types
+
+            overrides = MAGIC_OVERRIDES.get(name, {})
+
+            component_type = overrides.get("component_type", default_component_type)
+
+            extra_payload_values = overrides.get("payload_values", {})
 
             discovery_topic = f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
             # print(discovery_topic, state_topic)
@@ -56,16 +131,17 @@ def publish_ha_discovery(device, client, mqtt_topic):
                 "device": device_info,
                 "state_topic": f"{mqtt_topic}/state",
                 # "availability_topic": f"{mqtt_topic}/LWT",
-                "value_template": "{{value_json." + name + "}}",
+                "value_template": "{{value_json." + name + " | default('unavailable')}}",
                 "object_id": f"{device_ident}_{name}",
                 "unique_id": f"{device_ident}_{name}",
+                **extra_payload_values
             }
 
             if component_type == "binary_sensor":
-                discovery_payload["payload_on"] = "On"
-                discovery_payload["payload_off"] = "Off"
+                discovery_payload.setdefault("payload_on", "On")
+                discovery_payload.setdefault("payload_off", "Off")
 
-            print(discovery_topic)
+            # print(discovery_topic)
             # print(discovery_payload)
 
             client.publish(discovery_topic, json.dumps(discovery_payload), retain=True)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -12,13 +12,6 @@ def decamelcase(str):
 HA_DISCOVERY_PREFIX = "homeassistant"
 
 
-def publish_ha_states(state, client, mqtt_topic):
-    for key, value in state.items():
-        state_topic = f"{mqtt_topic}/{key}"
-        print(f"{now()} Publishing state for {key} at {state_topic}")
-        client.publish(state_topic, json.dumps(value))
-
-
 def publish_ha_discovery(device, client, mqtt_topic):
     print(f"{now()} Publishing HA discovery for {device}")
 
@@ -56,13 +49,14 @@ def publish_ha_discovery(device, client, mqtt_topic):
             component_type = "sensor" # TODO use appropriate types
 
             discovery_topic = f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
-            state_topic = f"{mqtt_topic}/{name}"
             # print(discovery_topic, state_topic)
 
             discovery_payload = json.dumps({
                 "name": decamelcase(name),
                 "device": device_info,
-                "state_topic": state_topic,
+                "state_topic": f"{mqtt_topic}/state",
+                "availability_topic": f"{mqtt_topic}/LWT",
+                "value_template": "{{value_json." + name + "}}",
                 "object_id": f"{device_ident}_{name}",
                 "unique_id": f"{device_ident}_{name}",
             })

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -46,21 +46,26 @@ def publish_ha_discovery(device, client, mqtt_topic):
             feature_type == "Event" or \
             feature_type == "Option":
 
-            component_type = "sensor" # TODO use appropriate types
+            component_type = "binary_sensor" if feature_type == "Event" else "sensor" # TODO use more appropriate types
 
             discovery_topic = f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{name}/config"
             # print(discovery_topic, state_topic)
 
-            discovery_payload = json.dumps({
+            discovery_payload = {
                 "name": decamelcase(name),
                 "device": device_info,
                 "state_topic": f"{mqtt_topic}/state",
-                "availability_topic": f"{mqtt_topic}/LWT",
+                # "availability_topic": f"{mqtt_topic}/LWT",
                 "value_template": "{{value_json." + name + "}}",
                 "object_id": f"{device_ident}_{name}",
                 "unique_id": f"{device_ident}_{name}",
-            })
+            }
+
+            if component_type == "binary_sensor":
+                discovery_payload["payload_on"] = "On"
+                discovery_payload["payload_off"] = "Off"
+
             print(discovery_topic)
             # print(discovery_payload)
 
-            client.publish(discovery_topic, discovery_payload, retain=True)
+            client.publish(discovery_topic, json.dumps(discovery_payload), retain=True)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -43,12 +43,15 @@ def publish_ha_discovery(device, client, mqtt_topic):
     }
 
     for feature in device["features"].values():
+        name_parts = feature["name"].split(".")
+        name = name_parts[-1]
+        feature_type = name_parts[-2]
         access = feature.get("access", "none")
         available = feature.get("available", False)
-        if available and (access == "read" or access == "readWrite"):
-            name_parts = feature["name"].split(".")
-            name = name_parts[-1]
-            # feature_type = name_parts[-2]
+
+        if (feature_type == "Setting" and available and (access == "read" or access == "readWrite")) or \
+            feature_type == "Event" or \
+            feature_type == "Option":
 
             component_type = "sensor" # TODO use appropriate types
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -19,6 +19,13 @@ HA_DISCOVERY_PREFIX = "homeassistant"
 # Note: keys should be integer (not string) taken from a device's feature
 # mapping.
 MAGIC_OVERRIDES = {
+    3: {  # BSH.Common.Setting.AllowBackendConnection
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
     5: {  # BSH.Common.Status.BackendConnected
         "component_type": "binary_sensor",
         "payload_values": {
@@ -31,6 +38,35 @@ MAGIC_OVERRIDES = {
         "component_type": "binary_sensor",
         "payload_values": {
             "device_class": "update",
+            "payload_on": "Present"
+        }
+    },
+    523: {  # BSH.Common.Status.RemoteControlActive
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    524: {  # BSH.Common.Status.RemoteControlStartAllowed
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    524: {  # BSH.Common.Setting.ChildLock
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "lock",
+            "payload_on": False,  # Lock "on" means "unlocked" to HA
+            "payload_off": True,  # Lock "off" means "locked"
+        }
+    },
+    525: {  # BSH.Common.Event.AquaStopOccured
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
             "payload_on": "Present"
         }
     },
@@ -48,6 +84,91 @@ MAGIC_OVERRIDES = {
             "device_class": "power"
         }
     },
+    542: {  # BSH.Common.Option.ProgramProgress
+        "payload_values": {
+            "unit_of_measurement": "%"
+        }
+    },
+    543: {  # BSH.Common.Event.LowWaterPressure
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    544: {  # BSH.Common.Option.RemainingProgramTime
+        "payload_values": {
+            "unit_of_measurement": "s",
+            "device_class": "duration"
+        }
+    },
+    549: {  # BSH.Common.Option.RemainingProgramTimeIsEstimated
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    558: {  # BSH.Common.Option.StartInRelative
+        "payload_values": {
+            "unit_of_measurement": "s",
+            "device_class": "duration"
+        }
+    },
+    4101: {  # Dishcare.Dishwasher.Status.SilenceOnDemandRemainingTime
+        "payload_values": {
+            "unit_of_measurement": "s",
+            "device_class": "duration"
+        }
+    },
+    4103: {  # Dishcare.Dishwasher.Status.EcoDryActive
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    4382: {  # Dishcare.Dishwasher.Status.SilenceOnDemandDefaultTime
+        "payload_values": {
+            "unit_of_measurement": "s",
+            "device_class": "duration"
+        }
+    },
+    4384: {  # Dishcare.Dishwasher.Setting.SpeedOnDemand
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    4608: {  # Dishcare.Dishwasher.Event.InternalError
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    4609: {  # Dishcare.Dishwasher.Event.CheckFilterSystem
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    4610: {  # Dishcare.Dishwasher.Event.DrainingNotPossible
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    4611: {  # Dishcare.Dishwasher.Event.DrainPumpBlocked
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
     4612: {  # Dishcare.Dishwasher.Event.WaterheaterCalcified
         "component_type": "binary_sensor",
         "payload_values": {
@@ -55,14 +176,21 @@ MAGIC_OVERRIDES = {
             "payload_on": "Present"
         }
     },
-    5624: {  # Dishcare.Dishwasher.Event.SaltLack
+    4613: {  # Dishcare.Dishwasher.Event.LowVoltage
         "component_type": "binary_sensor",
         "payload_values": {
             "device_class": "problem",
             "payload_on": "Present"
         }
     },
-    5625: {  # Dishcare.Dishwasher.Event.RinseAidLack
+    4624: {  # Dishcare.Dishwasher.Event.SaltLack
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "device_class": "problem",
+            "payload_on": "Present"
+        }
+    },
+    4625: {  # Dishcare.Dishwasher.Event.RinseAidLack
         "component_type": "binary_sensor",
         "payload_values": {
             "device_class": "problem",
@@ -76,11 +204,39 @@ MAGIC_OVERRIDES = {
             "payload_on": "Present"
         }
     },
-    5627: {  # Dishcare.Dishwasher.Event.RinseAidNearlyEmpty
+    4627: {  # Dishcare.Dishwasher.Event.RinseAidNearlyEmpty
         "component_type": "binary_sensor",
         "payload_values": {
             "device_class": "problem",
             "payload_on": "Present"
+        }
+    },
+    5121: {  # Dishcare.Dishwasher.Option.ExtraDry
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    5124: {  # Dishcare.Dishwasher.Option.HalfLoad
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    5127: {  # Dishcare.Dishwasher.Option.VarioSpeedPlus
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
+        }
+    },
+    5136: {  # Dishcare.Dishwasher.Option.SilenceOnDemand
+        "component_type": "binary_sensor",
+        "payload_values": {
+            "payload_on": True,
+            "payload_off": False
         }
     },
 }
@@ -90,6 +246,8 @@ def augment_device_features(features):
     for id, feature in features.items():
         if id in MAGIC_OVERRIDES:
             feature["discovery"] = MAGIC_OVERRIDES[id]
+        # else:
+        #     print(f"No discovery information for: {id} => {feature['name']}", file=sys.stderr)
     return features
 
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ mqtt_cafile = None
 mqtt_certfile = None
 mqtt_keyfile = None
 mqtt_clientname="hcpy"
+ha_discovery = True  # See section on "Home Assistant autodiscovery"
 ```
 
 ```bash
@@ -456,3 +457,48 @@ To start a dishwasher on eco mode in 10 miuntes (`BSH.Common.Option.StartInRelat
 ## Notes
 - Sometimes when the device is off, there is the error `ERROR [ip] [Errno 113] No route to host`
 - There is a lot more information available, like the status of a program that is currently active. This needs to be integrated if possible. For now only the values that relate to the `config.json` are published
+
+## Home Assistant autodiscovery
+
+It's possible to allow Home Assistant to automatically discover the device using
+MQTT auto-discovery messages. With `ha_discovery = True` in `config.ini` or by
+passing `--ha-discovery` on the commandline, `hcpy` will publish
+[HA discovery messages](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)
+for each recognised property of your devices.
+
+### Limitations
+
+Discovery messages currently only contain a `state` topic, not a `command` topic,
+so autodiscovered devices will be read-only. You can still use the method
+described in `Posting to the appliance` above.
+
+### Customising the discovery messages
+
+`hcpy` will make some attempt to use the correct [component](https://www.home-assistant.io/integrations/mqtt/#configuration)
+and for some devices set an appropriate [device class](https://www.home-assistant.io/integrations/binary_sensor/#device-class).
+You can customise these by editing your `devices.json` to add or edit the
+`discovery` section for each feature. For example:
+
+```json
+[
+    { // ...
+        "features": {
+            // ...
+            "549": {
+                "name": "BSH.Common.Option.RemainingProgramTimeIsEstimated",
+                "discovery": {
+                    "component_type": "binary_sensor",
+                    "payload_values": {
+                        "payload_on": true,
+                        "payload_off": false
+                    }
+                }
+            }
+        }
+    }
+]
+```
+
+You may include arbitrary `payload_values` that are included in the MQTT discovery
+messages published when `hcpy` starts. Default values are set in `HADiscovery.py`
+for known devices/attributes. No validation is performed against these values.

--- a/hc-login.py
+++ b/hc-login.py
@@ -17,6 +17,7 @@ from Crypto.Hash import SHA256
 from Crypto.Random import get_random_bytes
 
 from HCxml2json import xml2json
+from HADiscovery import augment_device_features
 
 # These two lines enable debugging at httplib level (requests->urllib3->http.client)
 # You will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
@@ -310,6 +311,6 @@ for app in account["data"]["homeAppliances"]:
 
     machine = xml2json(features, description)
     config["description"] = machine["description"]
-    config["features"] = machine["features"]
+    config["features"] = augment_device_features(machine["features"])
 
 print(json.dumps(configs, indent=4))

--- a/hc-login.py
+++ b/hc-login.py
@@ -16,8 +16,8 @@ from bs4 import BeautifulSoup
 from Crypto.Hash import SHA256
 from Crypto.Random import get_random_bytes
 
-from HCxml2json import xml2json
 from HADiscovery import augment_device_features
+from HCxml2json import xml2json
 
 # These two lines enable debugging at httplib level (requests->urllib3->http.client)
 # You will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -13,7 +13,7 @@ import paho.mqtt.client as mqtt
 
 from HCDevice import HCDevice
 from HCSocket import HCSocket, now
-from HADiscovery import publish_ha_states, publish_ha_discovery
+from HADiscovery import publish_ha_discovery
 
 
 @click.command()
@@ -153,7 +153,7 @@ def hc2mqtt(
     for device in devices:
         mqtt_topic = mqtt_prefix + device["host"]
         thread = Thread(
-            target=client_connect, args=(client, device, mqtt_topic, domain_suffix, debug, ha_discovery)
+            target=client_connect, args=(client, device, mqtt_topic, domain_suffix, debug)
         )
         thread.start()
 
@@ -164,7 +164,7 @@ global dev
 dev = {}
 
 
-def client_connect(client, device, mqtt_topic, domain_suffix, debug, ha_discovery):
+def client_connect(client, device, mqtt_topic, domain_suffix, debug):
     host = device["host"]
     name = device["name"]
 
@@ -198,8 +198,6 @@ def client_connect(client, device, mqtt_topic, domain_suffix, debug, ha_discover
                     msg = json.dumps(state)
                     print(now(), name, f"publish to {mqtt_topic} with {msg}")
                     client.publish(f"{mqtt_topic}/state", msg, retain=True)
-                    if ha_discovery:
-                        publish_ha_states(state, client, mqtt_topic)
                 else:
                     print(
                         now(),

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -11,9 +11,9 @@ import click
 import click_config_file
 import paho.mqtt.client as mqtt
 
+from HADiscovery import publish_ha_discovery
 from HCDevice import HCDevice
 from HCSocket import HCSocket, now
-from HADiscovery import publish_ha_discovery
 
 
 @click.command()
@@ -46,7 +46,7 @@ def hc2mqtt(
     mqtt_clientname: str,
     domain_suffix: str,
     debug: bool,
-    ha_discovery: bool
+    ha_discovery: bool,
 ):
 
     def on_connect(client, userdata, flags, rc):


### PR DESCRIPTION
This PR adds support for Home Assistant's [MQTT auto-discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) mechanism.

This works in two parts:

- When `hc-login.py` is run, it compares each device feature against a list of manually-curated discovery settings. If found, it includes the additional settings in the output for `devices.json`.
- When `hc2mqtt.py` is run, at startup, for each feature of each device, it will publish a discovery message to a specific path under `/homeassistant` based on that feature's properties. It makes some attempt to decide if the feature should be classed as a `sensor` or `binary_sensor`, and will override its decision with a value from `devices.json` if present. Each discovery message points HA to the main state message path, and provides a `value_template` to tell Home Assistant how to extract the appropriate value from the main state object.

By including the discovery settings in `devices.json`, users can change or add to auto-discovery configuration without needing to change the code of `hcpy; so support for new devices or features can be added easily.

I've only got a dishwasher, so I've only included configuration overrides for features relevant to that. It should be self-explanatory how to add additional overrides in `HADiscovery.py` to support other devices - although this works on the basis of progressive enhancement, so values will still _appear_ even without specific support; it just means they'll be a generic `sensor` and lack domain-specific terminology and iconography in HA.

Here's an example of what appears in Home Assistant without configuration:

![ha_dishwasher_autodiscovery](https://github.com/user-attachments/assets/76294288-5f96-4721-9780-452566be604b)

![ha_dishwasher_autodiscovery_2](https://github.com/user-attachments/assets/1f7ff76f-f79c-49ce-ae85-46b53317dc0d)

Note the use of appropriate icons/labels for things like the child lock and door state; remaining program time is rendered usefully as HH:MM rather than a number of seconds; warnings like "Rinse aid lack" are marked as "OK" (and, if triggered, will be listed as "Problem") etc.

Resolves #52.