### PR TITLE
Delete dots from device_ident in HADiscovery.py

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -163,7 +163,7 @@ def augment_device_features(features):
 def publish_ha_discovery(device, client, mqtt_topic):
     print(f"{now()} Publishing HA discovery for {device}")
 
-    device_ident = device["host"].replace('.', '')
+    device_ident = device["host"].replace(".", "")
     device_name = device["name"]
     device_description = device.get("description", {})
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -163,7 +163,7 @@ def augment_device_features(features):
 def publish_ha_discovery(device, client, mqtt_topic):
     print(f"{now()} Publishing HA discovery for {device}")
 
-    device_ident = device["host"]
+    device_ident = device["host"].replace('.', '')
     device_name = device["name"]
     device_description = device.get("description", {})
 


### PR DESCRIPTION
If hosts uses FQDN (with dots, ie BOSCH-Washer-SERIAL.localdomain), then HA logs errors on discovery:

Received message on illegal discovery topic 'homeassistant/sensor/hcpy/BOSCH-Washer-SERIAL.localdomain_WaterAndRinsePlus/config'. The topic contains not allowed characters. For more information see https://www.home-assistant.io/integrations/mqtt/#discovery-topic