### PR TITLE
Fix mqtt_topic value

### DIFF
--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -57,6 +57,7 @@ def hc2mqtt(
             client.publish(f"{mqtt_prefix}LWT", payload="online", qos=0, retain=True)
             # Re-subscribe to all device topics on reconnection
             for device in devices:
+                mqtt_topic = f"{mqtt_prefix}{device['host']}"
                 mqtt_set_topic = f"{mqtt_prefix}{device['name']}/set"
                 print(now(), device["name"], f"set topic: {mqtt_set_topic}")
                 client.subscribe(mqtt_set_topic)


### PR DESCRIPTION
mqtt_topic value, used in

`publish_ha_discovery(device, client, mqtt_topic)`

needs to be set every cycle, otherwise if you have more than one home connect device the value is stale (it's always the same, equal to the last device in devices.json), leading to wrong topic subscription.