### PR TITLE
Revert host to name in mqtt topic

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -163,8 +163,7 @@ def augment_device_features(features):
 def publish_ha_discovery(device, client, mqtt_topic):
     print(f"{now()} Publishing HA discovery for {device}")
 
-    device_ident = device["host"]
-    device_name = device["name"]
+    device_ident = device["name"]
     device_description = device.get("description", {})
 
     version_parts = filter(
@@ -174,7 +173,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
 
     device_info = {
         "identifiers": [device_ident],
-        "name": device_name,
+        "name": device_ident,
         "manufacturer": device_description.get("brand"),
         "model": device_description.get("model"),
         "sw_version": ".".join(version_parts),

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -57,6 +57,7 @@ def hc2mqtt(
             client.publish(f"{mqtt_prefix}LWT", payload="online", qos=0, retain=True)
             # Re-subscribe to all device topics on reconnection
             for device in devices:
+                mqtt_topic = f"{mqtt_prefix}{device['name']}"
                 mqtt_set_topic = f"{mqtt_prefix}{device['name']}/set"
                 print(now(), device["name"], f"set topic: {mqtt_set_topic}")
                 client.subscribe(mqtt_set_topic)
@@ -151,7 +152,7 @@ def hc2mqtt(
     client.connect(host=mqtt_host, port=mqtt_port, keepalive=70)
 
     for device in devices:
-        mqtt_topic = mqtt_prefix + device["host"]
+        mqtt_topic = mqtt_prefix + device["name"]
         thread = Thread(
             target=client_connect, args=(client, device, mqtt_topic, domain_suffix, debug)
         )


### PR DESCRIPTION
Following discussion in #88 , this PR aims to revert the change from host to name in mqtt topic.

This fixes:
#92 
#91 

and supersedes:
#89 
#90 