### PR TITLE
Execute hc login on first run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10-slim
 
 ARG BASHIO_VERSION="v0.16.2"
+ARG BASHIO_SHA256="d0f0c780c4badd103c00c572b1bf9645520d15a8a8070d6e3d64e35cb9f583aa"
 
 WORKDIR /app
 
@@ -13,6 +14,7 @@ RUN apt-get update && \
   apt-get autoremove -y \
     && curl -J -L -o /tmp/bashio.tar.gz \
         "https://github.com/hassio-addons/bashio/archive/${BASHIO_VERSION}.tar.gz" \
+    && echo "${BASHIO_SHA256} /tmp/bashio.tar.gz" | sha256sum --check \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
 FROM python:3.10-slim
 
+ARG BASHIO_VERSION="v0.16.2"
+
 WORKDIR /app
 
 COPY requirements.txt ./
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends gcc python3-dev libssl-dev libxml2-dev libxslt-dev python3-dev jq && \
+  apt-get install -y --no-install-recommends curl tar gcc python3-dev libssl-dev libxml2-dev libxslt-dev python3-dev jq && \
   pip3 install -r requirements.txt && \
   apt-get remove -y gcc python3-dev libssl-dev && \
-  apt-get autoremove -y
+  apt-get autoremove -y \
+    && curl -J -L -o /tmp/bashio.tar.gz \
+        "https://github.com/hassio-addons/bashio/archive/${BASHIO_VERSION}.tar.gz" \
+    && mkdir /tmp/bashio \
+    && tar zxvf \
+        /tmp/bashio.tar.gz \
+        --strip 1 -C /tmp/bashio \
+    && mv /tmp/bashio/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio
 
 COPY hc2mqtt.py hc-login.py HADiscovery.py HCDevice.py HCSocket.py HCxml2json.py run.sh ./
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Installing `sslpsk` needs some extra steps:
 ![laptop in a clothes washer with a display DoorState:Closed](images/doorclose.jpg)
 
 ```bash
-hc-login.py $USERNAME $PASSWORD > config/devices.json
+hc-login.py $USERNAME $PASSWORD config/devices.json
 ```
 
 or

--- a/hc-login.py
+++ b/hc-login.py
@@ -316,3 +316,5 @@ for app in account["data"]["homeAppliances"]:
 
 with open(devicefile, 'w') as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)
+
+print("Success. You can now edit "+devicefile+", if needed, and run hc2mqtt.py or start Home Assistant addon again")  

--- a/hc-login.py
+++ b/hc-login.py
@@ -38,6 +38,7 @@ def debug(*args):
 
 email = sys.argv[1]
 password = sys.argv[2]
+devicefile = sys.argv[3]
 
 headers = {"User-Agent": "hc-login/1.0"}
 
@@ -313,4 +314,5 @@ for app in account["data"]["homeAppliances"]:
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
 
-print(json.dumps(configs, indent=4))
+with open(devicefile, 'w') as f:
+    json.dump(configs, f, ensure_ascii=True, indent=4)

--- a/hc-login.py
+++ b/hc-login.py
@@ -314,7 +314,11 @@ for app in account["data"]["homeAppliances"]:
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
 
-with open(devicefile, 'w') as f:
+with open(devicefile, "w") as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)
 
-print("Success. You can now edit "+devicefile+", if needed, and run hc2mqtt.py or start Home Assistant addon again")  
+print(
+    "Success. You can now edit "
+    + devicefile
+    + ", if needed, and run hc2mqtt.py or start Home Assistant addon again"
+)

--- a/hc-login.py
+++ b/hc-login.py
@@ -313,6 +313,7 @@ for app in account["data"]["homeAppliances"]:
     machine = xml2json(features, description)
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
+    print("Discovered device: "+config["name"]+" - Device hostname: "+config["host"])
 
 with open(devicefile, "w") as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)

--- a/hc-login.py
+++ b/hc-login.py
@@ -313,7 +313,7 @@ for app in account["data"]["homeAppliances"]:
     machine = xml2json(features, description)
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
-    print("Discovered device: "+config["name"]+" - Device hostname: "+config["host"])
+    print("Discovered device: " + config["name"] + " - Device hostname: " + config["host"])
 
 with open(devicefile, "w") as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -17,7 +17,7 @@ map:
 url: https://github.com/hcpy2-0/hcpy
 panel_title: HCPY
 options:
-  HCPY_DEVICES_FILE: "config/devices.json"
+  HCPY_DEVICES_FILE: "/config/devices.json"
   HCPY_MQTT_HOST: localhost
   HCPY_MQTT_PORT: 1883
   HCPY_MQTT_PREFIX: "homeconnect/"

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -12,6 +12,7 @@ arch:
   - armv7
   - i386
 map:
+  - addon_config:rw
   - share
 url: https://github.com/hcpy2-0/hcpy
 panel_title: HCPY
@@ -30,6 +31,8 @@ options:
   HCPY_HA_DISCOVERY: true
   HCPY_DOMAIN_SUFFIX: ""
   HCPY_DEBUG: false
+  HCPY_HOMECONNECT_EMAIL: ""
+  HCPY_HOMECONNECT_PASSWORD: ""
 schema:
   HCPY_DEVICES_FILE: str
   HCPY_MQTT_HOST: str
@@ -45,4 +48,6 @@ schema:
   HCPY_DOMAIN_SUFFIX: str
   HCPY_HA_DISCOVERY: bool?
   HCPY_DEBUG: bool?
+  HCPY_HOMECONNECT_EMAIL: email
+  HCPY_HOMECONNECT_PASSWORD: password
 startup: services

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bashio
 CONFIG_PATH=/data/options.json
 if [ -f ${CONFIG_PATH} ]; then
+
         set -o allexport
         HCPY_DEVICES_FILE="$(bashio::config 'HCPY_DEVICES_FILE')"
         HCPY_MQTT_HOST="$(bashio::config 'HCPY_MQTT_HOST')"
@@ -19,13 +20,12 @@ if [ -f ${CONFIG_PATH} ]; then
         HCPY_HOMECONNECT_EMAIL="$(bashio::config 'HCPY_HOMECONNECT_EMAIL')"
         HCPY_HOMECONNECT_PASSWORD="$(bashio::config 'HCPY_HOMECONNECT_PASSWORD')"
         set +o allexport
-fi
-if [ ! -f "${HCPY_DEVICES_FILE}" ]; then
-        echo "File not found ${HCPY_DEVICES_FILE}"
-        echo "Trying to retrieve devices.json"
-        exec python3 hc-login.py $HCPY_HOMECONNECT_EMAIL $HCPY_HOMECONNECT_PASSWORD ${HCPY_DEVICES_FILE}
-fi
-if [ -f ${CONFIG_PATH} ]; then
-    exec python3 hc2mqtt.py
+        
+        if [ ! -f "${HCPY_DEVICES_FILE}" ]; then
+                echo "File not found ${HCPY_DEVICES_FILE}"
+                echo "Trying to retrieve devices.json"
+                exec python3 hc-login.py $HCPY_HOMECONNECT_EMAIL $HCPY_HOMECONNECT_PASSWORD ${HCPY_DEVICES_FILE}
+        fi
+        exec python3 hc2mqtt.py
 fi
 exec python3 hc2mqtt.py --config ./config/config.ini

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,31 @@
-#!/bin/bash
-if [ -f /data/options.json ]; then
-    set -o allexport
-    eval "$(jq -r 'to_entries[]|"\(.key)=\"\(.value)\""' /data/options.json)"
-    set +o allexport
+#!/usr/bin/env bashio
+CONFIG_PATH=/data/options.json
+if [ -f ${CONFIG_PATH} ]; then
+        set -o allexport
+        HCPY_DEVICES_FILE="$(bashio::config 'HCPY_DEVICES_FILE')"
+        HCPY_MQTT_HOST="$(bashio::config 'HCPY_MQTT_HOST')"
+        HCPY_MQTT_PORT="$(bashio::config 'HCPY_MQTT_PORT')"
+        HCPY_MQTT_PREFIX="$(bashio::config 'HCPY_MQTT_PREFIX')"
+        HCPY_MQTT_USERNAME="$(bashio::config 'HCPY_MQTT_USERNAME')"
+        HCPY_MQTT_PASSWORD="$(bashio::config 'HCPY_MQTT_PASSWORD')"
+        HCPY_MQTT_SSL="$(bashio::config 'HCPY_MQTT_SSL')"
+        HCPY_MQTT_CAFILE="$(bashio::config 'HCPY_MQTT_CAFILE')"
+        HCPY_MQTT_CERTFILE="$(bashio::config 'HCPY_MQTT_CERTFILE')"
+        HCPY_MQTT_KEYFILE="$(bashio::config 'HCPY_MQTT_KEYFILE')"
+        HCPY_MQTT_CLIENTNAME="$(bashio::config 'HCPY_MQTT_CLIENTNAME')"
+        HCPY_HA_DISCOVERY="$(bashio::config 'HCPY_HA_DISCOVERY')"
+        HCPY_DOMAIN_SUFFIX="$(bashio::config 'HCPY_DOMAIN_SUFFIX')"
+        HCPY_DEBUG="$(bashio::config 'HCPY_DEBUG')"
+        HCPY_HOMECONNECT_EMAIL="$(bashio::config 'HCPY_HOMECONNECT_EMAIL')"
+        HCPY_HOMECONNECT_PASSWORD="$(bashio::config 'HCPY_HOMECONNECT_PASSWORD')"
+        set +o allexport
+fi
+if [ ! -f "${HCPY_DEVICES_FILE}" ]; then
+        echo "File not found ${HCPY_DEVICES_FILE}"
+        echo "Trying to retrieve devices.json"
+        exec python3 hc-login.py $HCPY_HOMECONNECT_EMAIL $HCPY_HOMECONNECT_PASSWORD ${HCPY_DEVICES_FILE}
+fi
+if [ -f ${CONFIG_PATH} ]; then
     exec python3 hc2mqtt.py
 fi
 exec python3 hc2mqtt.py --config ./config/config.ini


### PR DESCRIPTION
This PR aims to execute hc-login.py directly on first run of home assistant add-on. Two new text inputs has been added to HA addon configuration (HC email & password) and will be passed to hc-login.py.

Resolves:
- #53 
- #79 "Mqtt sppecial characters for passwords are not recognised - for instance $$ is converted to 1." as now the options are parsed using recommended [bashio](https://github.com/hassio-addons/bashio) and this issue is fixed.

### Notable changes

- [bashio](https://github.com/hassio-addons/bashio) is used instead of jq to parse options in run.sh. I don't know if jq is used elsewhere, if not  we will need to remove it in dockerfile (bashio is recommended in [HA addons documentation](https://developers.home-assistant.io/docs/add-ons/configuration#add-on-script))
- now the [addon_config ](https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-advanced-options) is mapped also, and in configuration will use this path by default instead of /share/ which I currently left there but I think we will need to remove it any time soon. Use addon_config is best practice on HA addons for a use case like this one. Also, this is included in add-on backups unlike /share/.
- hc-login.py does not print devices.json on stdout, instead an arg for the filename has beed added to the script so that the errors will be printed on stdout (and so, in the addon logs) instead of the file. Also, now it prints the discovered devices' names and hostnames in stdout so they can be seen in addon's logs.