### PR TITLE
Add basic control ha discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
 FROM python:3.10-slim
 
+ARG BASHIO_VERSION="v0.16.2"
+
 WORKDIR /app
 
 COPY requirements.txt ./
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends gcc python3-dev libssl-dev libxml2-dev libxslt-dev python3-dev jq && \
+  apt-get install -y --no-install-recommends curl tar gcc python3-dev libssl-dev libxml2-dev libxslt-dev python3-dev jq && \
   pip3 install -r requirements.txt && \
   apt-get remove -y gcc python3-dev libssl-dev && \
-  apt-get autoremove -y
+  apt-get autoremove -y \
+    && curl -J -L -o /tmp/bashio.tar.gz \
+        "https://github.com/hassio-addons/bashio/archive/${BASHIO_VERSION}.tar.gz" \
+    && mkdir /tmp/bashio \
+    && tar zxvf \
+        /tmp/bashio.tar.gz \
+        --strip 1 -C /tmp/bashio \
+    && mv /tmp/bashio/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio
 
 COPY hc2mqtt.py hc-login.py HADiscovery.py HCDevice.py HCSocket.py HCxml2json.py run.sh ./
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -6,7 +6,7 @@ from HCSocket import now
 
 def decamelcase(str):
     split = re.findall(r"[A-Z](?:[a-z]+|[A-Z]*(?=[A-Z]|$))", str)
-    if len(split)==0:
+    if len(split) == 0:
         return str
     return f"{split[0]} {' '.join(split[1:]).lower()}".strip()
 
@@ -61,9 +61,7 @@ MAGIC_OVERRIDES = {
         "component_type": "binary_sensor",
         "payload_values": {"device_class": "door", "payload_on": "Open", "payload_off": "Closed"},
     },
-    539: {  # BSH.Common.Setting.PowerState
-        "component_type": "switch"
-    },
+    539: {"component_type": "switch"},  # BSH.Common.Setting.PowerState
     542: {"payload_values": {"unit_of_measurement": "%"}},  # BSH.Common.Option.ProgramProgress
     543: {  # BSH.Common.Event.LowWaterPressure
         "component_type": "binary_sensor",
@@ -186,7 +184,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
         feature_type = name_parts[2]
         access = feature.get("access", "none")
         available = feature.get("available", False)
-        uid=int(uid)
+        uid = int(uid)
 
         if (
             (
@@ -245,11 +243,14 @@ def publish_ha_discovery(device, client, mqtt_topic):
             if component_type == "switch":
                 discovery_payload.setdefault("payload_on", "On")
                 discovery_payload.setdefault("payload_off", "Off")
-                discovery_payload.setdefault("command_topic", f'{mqtt_topic}/set')
-                discovery_payload.setdefault("command_template", f'{{ "uid":{uid}, "value": {{{{ iif(value=="On", 2,1) }}}} }}')
+                discovery_payload.setdefault("command_topic", f"{mqtt_topic}/set")
+                discovery_payload.setdefault(
+                    "command_template",
+                    f'{{ "uid":{uid}, "value": {{{{ iif(value=="On", 2,1) }}}} }}',
+                )
 
             if component_type == "button":
-                discovery_payload.setdefault("command_topic", f'{mqtt_topic}/activeProgram')
+                discovery_payload.setdefault("command_topic", f"{mqtt_topic}/activeProgram")
                 discovery_payload.setdefault("command_template", f'{{ "program":{uid} }}')
 
             # print(discovery_topic)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -6,6 +6,8 @@ from HCSocket import now
 
 def decamelcase(str):
     split = re.findall(r"[A-Z](?:[a-z]+|[A-Z]*(?=[A-Z]|$))", str)
+    if len(split)==0:
+        return str
     return f"{split[0]} {' '.join(split[1:]).lower()}".strip()
 
 
@@ -60,8 +62,7 @@ MAGIC_OVERRIDES = {
         "payload_values": {"device_class": "door", "payload_on": "Open", "payload_off": "Closed"},
     },
     539: {  # BSH.Common.Setting.PowerState
-        "component_type": "binary_sensor",
-        "payload_values": {"device_class": "power"},
+        "component_type": "switch"
     },
     542: {"payload_values": {"unit_of_measurement": "%"}},  # BSH.Common.Option.ProgramProgress
     543: {  # BSH.Common.Event.LowWaterPressure
@@ -179,12 +180,13 @@ def publish_ha_discovery(device, client, mqtt_topic):
         "sw_version": ".".join(version_parts),
     }
 
-    for feature in device["features"].values():
+    for uid, feature in device["features"].items():
         name_parts = feature["name"].split(".")
         name = name_parts[-1]
-        feature_type = name_parts[-2]
+        feature_type = name_parts[2]
         access = feature.get("access", "none")
         available = feature.get("available", False)
+        uid=int(uid)
 
         if (
             (
@@ -199,9 +201,15 @@ def publish_ha_discovery(device, client, mqtt_topic):
             )
             or feature_type == "Event"
             or feature_type == "Option"
+            or feature_type == "Program"
         ):
 
-            default_component_type = "binary_sensor" if feature_type == "Event" else "sensor"
+            if feature_type == "Event":
+                default_component_type = "binary_sensor"
+            elif feature_type == "Program":
+                default_component_type = "button"
+            else:
+                default_component_type = "sensor"
 
             overrides = feature.get("discovery", {})
 
@@ -233,6 +241,16 @@ def publish_ha_discovery(device, client, mqtt_topic):
             if component_type == "binary_sensor":
                 discovery_payload.setdefault("payload_on", "On")
                 discovery_payload.setdefault("payload_off", "Off")
+
+            if component_type == "switch":
+                discovery_payload.setdefault("payload_on", "On")
+                discovery_payload.setdefault("payload_off", "Off")
+                discovery_payload.setdefault("command_topic", f'{mqtt_topic}/set')
+                discovery_payload.setdefault("command_template", f'{{ "uid":{uid}, "value": {{{{ iif(value=="On", 2,1) }}}} }}')
+
+            if component_type == "button":
+                discovery_payload.setdefault("command_topic", f'{mqtt_topic}/activeProgram')
+                discovery_payload.setdefault("command_template", f'{{ "program":{uid} }}')
 
             # print(discovery_topic)
             # print(discovery_payload)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Installing `sslpsk` needs some extra steps:
 ![laptop in a clothes washer with a display DoorState:Closed](images/doorclose.jpg)
 
 ```bash
-hc-login.py $USERNAME $PASSWORD > config/devices.json
+hc-login.py $USERNAME $PASSWORD config/devices.json
 ```
 
 or

--- a/hc-login.py
+++ b/hc-login.py
@@ -316,3 +316,5 @@ for app in account["data"]["homeAppliances"]:
 
 with open(devicefile, 'w') as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)
+
+print("Success. You can now edit "+devicefile+", if needed, and run hc2mqtt.py or start Home Assistant addon again")  

--- a/hc-login.py
+++ b/hc-login.py
@@ -38,6 +38,7 @@ def debug(*args):
 
 email = sys.argv[1]
 password = sys.argv[2]
+devicefile = sys.argv[3]
 
 headers = {"User-Agent": "hc-login/1.0"}
 
@@ -313,4 +314,5 @@ for app in account["data"]["homeAppliances"]:
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
 
-print(json.dumps(configs, indent=4))
+with open(devicefile, 'w') as f:
+    json.dump(configs, f, ensure_ascii=True, indent=4)

--- a/hc-login.py
+++ b/hc-login.py
@@ -314,7 +314,11 @@ for app in account["data"]["homeAppliances"]:
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
 
-with open(devicefile, 'w') as f:
+with open(devicefile, "w") as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)
 
-print("Success. You can now edit "+devicefile+", if needed, and run hc2mqtt.py or start Home Assistant addon again")  
+print(
+    "Success. You can now edit "
+    + devicefile
+    + ", if needed, and run hc2mqtt.py or start Home Assistant addon again"
+)

--- a/hc-login.py
+++ b/hc-login.py
@@ -313,6 +313,7 @@ for app in account["data"]["homeAppliances"]:
     machine = xml2json(features, description)
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
+    print("Discovered device: "+config["name"]+" - Device hostname: "+config["host"])
 
 with open(devicefile, "w") as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)

--- a/hc-login.py
+++ b/hc-login.py
@@ -313,7 +313,7 @@ for app in account["data"]["homeAppliances"]:
     machine = xml2json(features, description)
     config["description"] = machine["description"]
     config["features"] = augment_device_features(machine["features"])
-    print("Discovered device: "+config["name"]+" - Device hostname: "+config["host"])
+    print("Discovered device: " + config["name"] + " - Device hostname: " + config["host"])
 
 with open(devicefile, "w") as f:
     json.dump(configs, f, ensure_ascii=True, indent=4)

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -17,7 +17,7 @@ map:
 url: https://github.com/hcpy2-0/hcpy
 panel_title: HCPY
 options:
-  HCPY_DEVICES_FILE: "config/devices.json"
+  HCPY_DEVICES_FILE: "/config/devices.json"
   HCPY_MQTT_HOST: localhost
   HCPY_MQTT_PORT: 1883
   HCPY_MQTT_PREFIX: "homeconnect/"

--- a/home-assistant-addon/config.yaml
+++ b/home-assistant-addon/config.yaml
@@ -12,6 +12,7 @@ arch:
   - armv7
   - i386
 map:
+  - addon_config:rw
   - share
 url: https://github.com/hcpy2-0/hcpy
 panel_title: HCPY
@@ -30,6 +31,8 @@ options:
   HCPY_HA_DISCOVERY: true
   HCPY_DOMAIN_SUFFIX: ""
   HCPY_DEBUG: false
+  HCPY_HOMECONNECT_EMAIL: ""
+  HCPY_HOMECONNECT_PASSWORD: ""
 schema:
   HCPY_DEVICES_FILE: str
   HCPY_MQTT_HOST: str
@@ -45,4 +48,6 @@ schema:
   HCPY_DOMAIN_SUFFIX: str
   HCPY_HA_DISCOVERY: bool?
   HCPY_DEBUG: bool?
+  HCPY_HOMECONNECT_EMAIL: email
+  HCPY_HOMECONNECT_PASSWORD: password
 startup: services

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bashio
 CONFIG_PATH=/data/options.json
 if [ -f ${CONFIG_PATH} ]; then
+
         set -o allexport
         HCPY_DEVICES_FILE="$(bashio::config 'HCPY_DEVICES_FILE')"
         HCPY_MQTT_HOST="$(bashio::config 'HCPY_MQTT_HOST')"
@@ -19,13 +20,12 @@ if [ -f ${CONFIG_PATH} ]; then
         HCPY_HOMECONNECT_EMAIL="$(bashio::config 'HCPY_HOMECONNECT_EMAIL')"
         HCPY_HOMECONNECT_PASSWORD="$(bashio::config 'HCPY_HOMECONNECT_PASSWORD')"
         set +o allexport
-fi
-if [ ! -f "${HCPY_DEVICES_FILE}" ]; then
-        echo "File not found ${HCPY_DEVICES_FILE}"
-        echo "Trying to retrieve devices.json"
-        exec python3 hc-login.py $HCPY_HOMECONNECT_EMAIL $HCPY_HOMECONNECT_PASSWORD ${HCPY_DEVICES_FILE}
-fi
-if [ -f ${CONFIG_PATH} ]; then
-    exec python3 hc2mqtt.py
+        
+        if [ ! -f "${HCPY_DEVICES_FILE}" ]; then
+                echo "File not found ${HCPY_DEVICES_FILE}"
+                echo "Trying to retrieve devices.json"
+                exec python3 hc-login.py $HCPY_HOMECONNECT_EMAIL $HCPY_HOMECONNECT_PASSWORD ${HCPY_DEVICES_FILE}
+        fi
+        exec python3 hc2mqtt.py
 fi
 exec python3 hc2mqtt.py --config ./config/config.ini

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,31 @@
-#!/bin/bash
-if [ -f /data/options.json ]; then
-    set -o allexport
-    eval "$(jq -r 'to_entries[]|"\(.key)=\"\(.value)\""' /data/options.json)"
-    set +o allexport
+#!/usr/bin/env bashio
+CONFIG_PATH=/data/options.json
+if [ -f ${CONFIG_PATH} ]; then
+        set -o allexport
+        HCPY_DEVICES_FILE="$(bashio::config 'HCPY_DEVICES_FILE')"
+        HCPY_MQTT_HOST="$(bashio::config 'HCPY_MQTT_HOST')"
+        HCPY_MQTT_PORT="$(bashio::config 'HCPY_MQTT_PORT')"
+        HCPY_MQTT_PREFIX="$(bashio::config 'HCPY_MQTT_PREFIX')"
+        HCPY_MQTT_USERNAME="$(bashio::config 'HCPY_MQTT_USERNAME')"
+        HCPY_MQTT_PASSWORD="$(bashio::config 'HCPY_MQTT_PASSWORD')"
+        HCPY_MQTT_SSL="$(bashio::config 'HCPY_MQTT_SSL')"
+        HCPY_MQTT_CAFILE="$(bashio::config 'HCPY_MQTT_CAFILE')"
+        HCPY_MQTT_CERTFILE="$(bashio::config 'HCPY_MQTT_CERTFILE')"
+        HCPY_MQTT_KEYFILE="$(bashio::config 'HCPY_MQTT_KEYFILE')"
+        HCPY_MQTT_CLIENTNAME="$(bashio::config 'HCPY_MQTT_CLIENTNAME')"
+        HCPY_HA_DISCOVERY="$(bashio::config 'HCPY_HA_DISCOVERY')"
+        HCPY_DOMAIN_SUFFIX="$(bashio::config 'HCPY_DOMAIN_SUFFIX')"
+        HCPY_DEBUG="$(bashio::config 'HCPY_DEBUG')"
+        HCPY_HOMECONNECT_EMAIL="$(bashio::config 'HCPY_HOMECONNECT_EMAIL')"
+        HCPY_HOMECONNECT_PASSWORD="$(bashio::config 'HCPY_HOMECONNECT_PASSWORD')"
+        set +o allexport
+fi
+if [ ! -f "${HCPY_DEVICES_FILE}" ]; then
+        echo "File not found ${HCPY_DEVICES_FILE}"
+        echo "Trying to retrieve devices.json"
+        exec python3 hc-login.py $HCPY_HOMECONNECT_EMAIL $HCPY_HOMECONNECT_PASSWORD ${HCPY_DEVICES_FILE}
+fi
+if [ -f ${CONFIG_PATH} ]; then
     exec python3 hc2mqtt.py
 fi
 exec python3 hc2mqtt.py --config ./config/config.ini


### PR DESCRIPTION
Hello!
With this PR I added two basic controls to HADiscovery.py:

- PowerState: this is now a switch, to turn on and off the device.
- Program: these are now buttons, to start programs.

Of course this is an experiment but it should work.

P.s.: devices.json needs to be regenerated or manually edited to change:
````
 "539": {
                "name": "BSH.Common.Setting.PowerState",
        ...
                "discovery": {
                    "component_type": "binary_sensor",
                    "payload_values": {
                        "device_class": "power"
                    }
                }
            },
````

to

````
 "539": {
                "name": "BSH.Common.Setting.PowerState",
        ...
                "discovery": {
                    "component_type": "switch"
                }
            },
````