### PR TITLE
Add basic controls to HADiscovery

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -199,7 +199,8 @@ def publish_ha_discovery(device, client, mqtt_topic):
             )
             or feature_type == "Event"
             or feature_type == "Option"
-            or feature_type == "Program"
+            # If it's a Program, check if BSH.Common.Status.OperationState has "Ready" as available option. If not, programs are read only.
+            or ( feature_type == "Program" and "1" in device["features"]["552"]["values"]) 
         ):
 
             if feature_type == "Event":

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -252,6 +252,8 @@ def publish_ha_discovery(device, client, mqtt_topic):
             if component_type == "button":
                 discovery_payload.setdefault("command_topic", f"{mqtt_topic}/activeProgram")
                 discovery_payload.setdefault("command_template", f'{{ "program":{uid} }}')
+                discovery_payload.setdefault("availability_topic ", f"{mqtt_topic}/state")
+                discovery_payload.setdefault("availability_template", "{{ 'online' if value_json.OperationState == 'Ready' else 'offline' }}")
 
             # print(discovery_topic)
             # print(discovery_payload)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -253,7 +253,10 @@ def publish_ha_discovery(device, client, mqtt_topic):
                 discovery_payload.setdefault("command_topic", f"{mqtt_topic}/activeProgram")
                 discovery_payload.setdefault("command_template", f'{{ "program":{uid} }}')
                 discovery_payload.setdefault("availability_topic ", f"{mqtt_topic}/state")
-                discovery_payload.setdefault("availability_template", "{{ 'online' if value_json.OperationState == 'Ready' else 'offline' }}")
+                discovery_payload.setdefault(
+                    "availability_template",
+                    "{{ 'online' if value_json.OperationState == 'Ready' else 'offline' }}",
+                )
 
             # print(discovery_topic)
             # print(discovery_payload)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -252,7 +252,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
             if component_type == "button":
                 discovery_payload.setdefault("command_topic", f"{mqtt_topic}/activeProgram")
                 discovery_payload.setdefault("command_template", f'{{ "program":{uid} }}')
-                discovery_payload.setdefault("availability_topic ", f"{mqtt_topic}/state")
+                discovery_payload.setdefault("availability_topic", f"{mqtt_topic}/state")
                 discovery_payload.setdefault(
                     "availability_template",
                     "{{ 'online' if value_json.OperationState == 'Ready' else 'offline' }}",

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -200,7 +200,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
             or feature_type == "Event"
             or feature_type == "Option"
             # If it's a Program, check if BSH.Common.Status.OperationState has "Ready" as available option. If not, programs are read only.
-            or ( feature_type == "Program" and "1" in device["features"]["552"]["values"]) 
+            or (feature_type == "Program" and "1" in device["features"]["552"]["values"])
         ):
 
             if feature_type == "Event":

--- a/README.md
+++ b/README.md
@@ -468,8 +468,7 @@ for each recognised property of your devices.
 
 ### Limitations
 
-Discovery messages currently only contain a `state` topic, not a `command` topic,
-so autodiscovered devices will be read-only. You can still use the method
+Command topic has been implemented only for Power control and Programs. If you need to control anything else you can still use the method
 described in `Posting to the appliance` above.
 
 ### Customising the discovery messages


### PR DESCRIPTION
Hello!
With this PR I added two basic controls to HADiscovery.py:

- PowerState: this is now a switch, to turn on and off the device.
- Program: these are now buttons, to start programs.

Of course this is an experiment but it should work.

P.s.: devices.json needs to be regenerated or manually edited to change:
````
 "539": {
                "name": "BSH.Common.Setting.PowerState",
        ...
                "discovery": {
                    "component_type": "binary_sensor",
                    "payload_values": {
                        "device_class": "power"
                    }
                }
            },
````

to

````
 "539": {
                "name": "BSH.Common.Setting.PowerState",
        ...
                "discovery": {
                    "component_type": "switch"
                }
            },
````

### Sample image for clothes washer
<img width="271" alt="Immagine 2024-09-26 164158" src="https://github.com/user-attachments/assets/9042ed42-dcec-449d-9159-bb94ff9fca32">
