### PR TITLE
fix: Resolve every enum there is in the xml blobs

### DIFF
--- a/HCxml2json.py
+++ b/HCxml2json.py
@@ -18,6 +18,9 @@ import xml.etree.ElementTree as ET
 
 def parse_xml_list(codes, entries, enums):
     for el in entries:
+        if "uid" not in el.attrib:
+            continue
+
         # not sure how to parse refCID and refDID
         uid = int(el.attrib["uid"], 16)
 
@@ -40,6 +43,10 @@ def parse_xml_list(codes, entries, enums):
             data["values"] = enums[enum_id]["values"]
 
         # codes[uid] = data
+
+        # parse recursively to also resolve enums in elements in e.g. <optionList> elements
+        if len(el) > 0:
+            parse_xml_list(codes, el, enums)
 
 
 def parse_machine_description(entries):
@@ -96,8 +103,8 @@ def xml2json(features_xml, description_xml):
             "values": values,
         }
 
-    for i in range(4, 8):
-        parse_xml_list(features, description[i], enums)
+    for description_item in description:
+        parse_xml_list(features, description_item, enums)
 
     # remove the duplicate uid field
     for uid in features:


### PR DESCRIPTION
I've noticed that nested enums did not get resolved correctly by the currently rather hackish XML2JSON parser.

With these changes, they now do, greatly improving the HA experience for my washing machine & dryer:

![image](https://github.com/user-attachments/assets/771cd953-5736-4bad-ac08-86dfcfe48d8a)
![image](https://github.com/user-attachments/assets/a7051283-1d50-43f4-9174-a13c92822173)

In the future, it should probably become a real parser that actually understands the format, however for now, I suppose this is good enough