### PR TITLE
Small fixes for docker-compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ hc-login.py $USERNAME $PASSWORD > config/devices.json
 or
 
 ```bash
-docker-compose build
-docker-compose run -T app /app/hc-login.py $USERNAME $PASSWORD > config/devices.json
+docker-compose -f compose.yaml build
+docker-compose -f compose.yaml run -T app /app/hc-login.py $USERNAME $PASSWORD config/devices.json
 ```
 
 The `hc-login.py ` script perfoms the OAuth process to login to your
@@ -89,7 +89,7 @@ hc2mqtt.py --config config/config.ini
 or
 
 ```bash
-docker-compose up
+docker-compose -f compose.yaml up
 ```
 
 This tool will establish websockets to the local devices and


### PR DESCRIPTION
Depending on what version of docker you have compose.yaml may need specifying. Additionally the arguments for hc-login.py have changed to take a filename to export to. 