### PR TITLE
BREAKING: Use fully qualified attribute names

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 from HCSocket import now
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -3,12 +3,6 @@ import re
 
 from HCSocket import now
 
-
-def decamelcase(str):
-    split = re.findall(r"[A-Z](?:[a-z]+|[A-Z]*(?=[A-Z]|$))", str)
-    return f"{split[0]} {' '.join(split[1:]).lower()}".strip()
-
-
 HA_DISCOVERY_PREFIX = "homeassistant"
 
 
@@ -215,7 +209,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
             # print(discovery_topic, state_topic)
 
             discovery_payload = {
-                "name": decamelcase(name),
+                "name": name,
                 "device": device_info,
                 "state_topic": f"{mqtt_topic}/state",
                 # "availability_topic": f"{mqtt_topic}/LWT",
@@ -224,7 +218,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
                 # # then back to their correct values on every disconnect/
                 # # reconnect. This leaves a lot of noise in the HA history, so
                 # # I felt things were better off without an `availability_topic`.
-                "value_template": "{{value_json." + name + " | default('unavailable')}}",
+                "value_template": "{{value_json['" + name + "'] | default('unavailable')}}",
                 "object_id": f"{device_ident}_{name}",
                 "unique_id": f"{device_ident}_{name}",
                 **extra_payload_values,

--- a/HCDevice.py
+++ b/HCDevice.py
@@ -95,8 +95,6 @@ class HCDevice:
                 if "values" in status and value_str in status["values"]:
                     value = status["values"][value_str]
 
-            # trim everything off the name except the last part
-            name = re.sub(r"^.*\.", "", name)
             result[name] = value
 
         return result


### PR DESCRIPTION
Resolves https://github.com/hcpy2-0/hcpy/issues/72

This is a breaking change that means manually configured MQTT configurations in HA will need updating. I don't have much experience running this with HADiscovery enabled so would be good to get some feedback if further changes are required for that. 

For example the `SetpointTemperature` in the following:

```
number:
  - name: "Set Point Temperature"
    unique_id: "freezer_set_point_temperature"
    state_topic: "homeconnect/freezer/state"
    value_template: "{{ value_json.SetpointTemperature }}"
    command_topic: "homeconnect/freezer/set"
    command_template: "[{\"uid\":8198,\"value\": {{ value }} }]"
    min: -26
    max: -16
    icon: mdi:snowflake-thermometer
    unit_of_measurement: "°C"
    availability:
      - topic:  "homeconnect/LWT"
      - topic:  "homeconnect/freezer/LWT"
    availability_mode: all
    device:
      identifiers: "freezer"
```

Needs to become:


```

number:
  - name: "Set Point Temperature"
    unique_id: "freezer_set_point_temperature"
    state_topic: "homeconnect/freezer/state"
    value_template: "{{ value_json['Refrigeration.Common.Setting.Freezer.SetpointTemperature'] }}"
    command_topic: "homeconnect/freezer/set"
    command_template: "[{\"uid\":8198,\"value\": {{ value }} }]"
    min: -26
    max: -16
    icon: mdi:snowflake-thermometer
    unit_of_measurement: "°C"
    availability:
      - topic:  "homeconnect/LWT"
      - topic:  "homeconnect/freezer/LWT"
    availability_mode: all
    device:
      identifiers: "freezer"
```

