### PR TITLE
When dynamic features are added to a device name may not be set

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -180,7 +180,7 @@ def publish_ha_discovery(device, client, mqtt_topic):
     }
 
     for feature in device["features"].values():
-        if not "name" in feature:
+        if "name" not in feature:
             continue
         name_parts = feature["name"].split(".")
         name = name_parts[-1]

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -180,6 +180,8 @@ def publish_ha_discovery(device, client, mqtt_topic):
     }
 
     for feature in device["features"].values():
+        if not "name" in feature:
+            continue
         name_parts = feature["name"].split(".")
         name = name_parts[-1]
         feature_type = name_parts[-2]

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -64,20 +64,21 @@ def hc2mqtt(
                 for value in device["features"]:
                     # If the device has the ActiveProgram feature it allows programs to be started
                     # and scheduled via /ro/activeProgram
-                    if "BSH.Common.Root.ActiveProgram" == device["features"][value]["name"]:
-                        mqtt_active_program_topic = f"{mqtt_prefix}{device['name']}/activeProgram"
-                        print(now(), device["name"], f"program topic: {mqtt_active_program_topic}")
-                        client.subscribe(mqtt_active_program_topic)
-                    # If the device has the SelectedProgram feature it allows programs to be
-                    # selected via /ro/selectedProgram
-                    if "BSH.Common.Root.SelectedProgram" == device["features"][value]["name"]:
-                        mqtt_selected_program_topic = (
-                            f"{mqtt_prefix}{device['name']}/selectedProgram"
-                        )
-                        print(
-                            now(), device["name"], f"program topic: {mqtt_selected_program_topic}"
-                        )
-                        client.subscribe(mqtt_selected_program_topic)
+                    if "name" in device["features"][value]:
+                        if "BSH.Common.Root.ActiveProgram" == device["features"][value]["name"]:
+                            mqtt_active_program_topic = f"{mqtt_prefix}{device['name']}/activeProgram"
+                            print(now(), device["name"], f"program topic: {mqtt_active_program_topic}")
+                            client.subscribe(mqtt_active_program_topic)
+                        # If the device has the SelectedProgram feature it allows programs to be
+                        # selected via /ro/selectedProgram
+                        if "BSH.Common.Root.SelectedProgram" == device["features"][value]["name"]:
+                            mqtt_selected_program_topic = (
+                                f"{mqtt_prefix}{device['name']}/selectedProgram"
+                            )
+                            print(
+                                now(), device["name"], f"program topic: {mqtt_selected_program_topic}"
+                            )
+                            client.subscribe(mqtt_selected_program_topic)
                 if ha_discovery:
                     publish_ha_discovery(device, client, mqtt_topic)
         else:


### PR DESCRIPTION
Features can be processed from incoming device messages and added to the list of device features. However we dont know the name of these features and therefore `name` may not be set. 

Added more robust checking to see if name is set.