### PR TITLE
Remove programs from HADiscovery

### DIFF
--- a/discovery.yaml
+++ b/discovery.yaml
@@ -56,6 +56,7 @@ EXPAND_NAME:
 SKIP_ENTITIES:
 - Dishcare.Dishwasher.Program.
 - BSH.Common.Root.
+- Cooking.Common.Program.Hood.
 DISABLED_ENTITIES:
 - Refrigeration.Common.Status.
 - Dishcare.Dishwasher.Command.LearningDishwasher.Proposal.

--- a/discovery.yaml
+++ b/discovery.yaml
@@ -54,9 +54,16 @@ EXPAND_NAME:
   Refrigeration.Common.Status.: 3
   Dishcare.Dishwasher.Command.LearningDishwasher.Proposal.: 5
 SKIP_ENTITIES:
-- Dishcare.Dishwasher.Program.
 - BSH.Common.Root.
+- Dishcare.Dishwasher.Program.
 - Cooking.Common.Program.Hood.
+- ConsumerProducts.CoffeeMaker.Program.
+- ConsumerProducts.CleaningRobot.Program.
+- LaundryCare.Dryer.Program.
+- LaundryCare.Washer.Program.
+- LaundryCare.WasherDryer.Program.
+- Cooking.Oven.Program.
+
 DISABLED_ENTITIES:
 - Refrigeration.Common.Status.
 - Dishcare.Dishwasher.Command.LearningDishwasher.Proposal.


### PR DESCRIPTION
Programs are just values that can be selected for activeProgram/selectedProgram and dont have state.