### PR TITLE
Disable dangerous commands by default

### DIFF
--- a/discovery.yaml
+++ b/discovery.yaml
@@ -73,6 +73,9 @@ SKIP_ENTITIES:
 DISABLED_ENTITIES:
 - Refrigeration.Common.Status.
 - Dishcare.Dishwasher.Command.LearningDishwasher.Proposal.
+- BSH.Common.Command.ApplyFactoryReset
+- BSH.Common.Command.ApplyNetworkReset
+- BSH.Common.Command.DeactivateWiFi
 
 DISABLED_EXCEPTIONS:
 - Refrigeration.Common.Status.Door.


### PR DESCRIPTION
FactoryReset/WifiReset/NetworkReset all come through as PRESS buttons and could accidentally be clicked in the UI without any confirmation. Disable these by default as people unlikely to use these controls via HA anyway.