### PR TITLE
Favourite program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## In Progress
 * Set cooking temps as C
+* Process BaseProgram as a selectable Program
 
 ## [0.4.3] - 2025-03-15
 ## What's Changed

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -247,7 +247,11 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic):
                 if step is not None:
                     discovery_payload["step"] = float(step)
 
-        if name == "BSH.Common.Root.ActiveProgram" or name == "BSH.Common.Root.SelectedProgram":
+        if (
+            name == "BSH.Common.Root.ActiveProgram"
+            or name == "BSH.Common.Root.SelectedProgram"
+            or name == "BSH.Common.Option.BaseProgram"
+        ):
             component_type = "select"
             options = []
             for k, v in device["features"].items():
@@ -260,6 +264,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic):
                     or "LaundryCare.Washer.Program." in v["name"]
                     or "LaundryCare.WasherDryer.Program." in v["name"]
                     or "Cooking.Oven.Program." in v["name"]
+                    or "BSH.Common.Program.Favorite." in v["name"]
                 ):
                     options.append(v["name"].split(".")[-1])
 
@@ -272,6 +277,11 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic):
                 discovery_payload["command_topic"] = f"{mqtt_topic}/activeProgram"
             elif name == "BSH.Common.Root.SelectedProgram":
                 discovery_payload["command_topic"] = f"{mqtt_topic}/selectedProgram"
+            elif name == "BSH.Common.Option.BaseProgram":
+                discovery_payload["command_template"] = (
+                    f'[{{"uid":{uid},"value":"{{{{value}}}}"}}]'
+                )
+                discovery_payload["command_topic"] = f"{mqtt_topic}/set"
 
         discovery_topic = (
             f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{feature_id}/config"

--- a/HCDevice.py
+++ b/HCDevice.py
@@ -177,7 +177,8 @@ class HCDevice:
             else:
                 program = data["program"]
 
-            if isinstance(program, int) or program.isdigit():
+            # Favorite Programs 001 passes the isdigit check so must be excluded
+            if isinstance(program, int) or (program.isdigit() and not program.startswith("00")):
                 # devices.json stores UID as string
                 name = self.get_feature_name(program)
                 if name is None:

--- a/HCDevice.py
+++ b/HCDevice.py
@@ -535,6 +535,13 @@ class HCDevice:
                     }
                 self.services_initialized = True
 
+            elif resource == "/ro/selectedProgram" or resource == "/ro/activeProgram":
+                code = msg.get("code", None)
+                if code is not None:
+                    self.print(f"Failed to set the program, error code: {code}")
+                else:
+                    pass
+
             else:
                 self.print("Unknown response or notify:", msg)
 


### PR DESCRIPTION
The BaseProgram appears to be linked via parentUID to Favorite.001. Make it a select like active/selected program. However, it isn't set like a Program...

Favorite.001 (and presumably 002 etc) can be chosen as the Selected/Active Program.

Reduced the amount of code covered by the features lock in `test_feature`

TODO: Should remove Favorite.001 from the baseprogram as makes a weird circular setting... 