### PR TITLE
This makes fields for time that have readWrite access writable.

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -244,7 +244,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 or (refCID == "02" and refDID == "80")
                 or (refCID == "81" and refDID == "60")
                 or (refCID == "10" and refDID == "81")
-                or (refCID == "10" and refDID == "82" and access == "readWrite")
+                or (refCID == "10" and refDID == "82" and access == "readwrite")
             ):
                 component_type = "number"
                 discovery_payload["command_topic"] = f"{mqtt_topic}/set"

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -244,6 +244,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 or (refCID == "02" and refDID == "80")
                 or (refCID == "81" and refDID == "60")
                 or (refCID == "10" and refDID == "81")
+                or (refCID == "10" and refDID == "82" and access == "readWrite")
             ):
                 component_type = "number"
                 discovery_payload["command_topic"] = f"{mqtt_topic}/set"

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -244,7 +244,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 or (refCID == "02" and refDID == "80")
                 or (refCID == "81" and refDID == "60")
                 or (refCID == "10" and refDID == "81")
-                or (refCID == "10" and refDID == "82" and access == "readwrite")
+                or (refCID == "10" and refDID == "82")
             ):
                 component_type = "number"
                 discovery_payload["command_topic"] = f"{mqtt_topic}/set"


### PR DESCRIPTION
Some examples of those are "BSH.Common.Option.Duration" and "Cooking.Oven.Setting.Cavity.001.AlarmClock" on ovens.

The first one is the one that determines the time after which the oven must be turned on.
The second one is similar but it doesn't turn off the oven, it just makes an alarm sound but the oven stays on.

Those will be number entities now.