### PR TITLE
Reduce file size of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY requirements.txt ./
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends curl tar gcc jq python3-dev libxml2-dev libxslt-dev && \
+  apt-get install -y --no-install-recommends curl && \
   pip3 install -r requirements.txt && \
   apt-get remove -y gcc python3-dev && \
   apt-get autoremove -y \

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   app:
-    name: hcpy:latest
+    image: hcpy:latest
     build: .
     restart: on-failure
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 ---
 services:
   app:
+    name: hcpy:latest
     build: .
     restart: on-failure
     volumes:


### PR DESCRIPTION
Reduces the image size from ~336 MB to ~226MB. With the Alpine image it would even be only ~100 MB. But Alpine seems to be known for making problems when it comes to Python.

As I do not know why the author of the Dockerfile added the packages that I removed, I cannot guarantee that it works. I run my docker container from the reduced image since two weeks and do not experience any problems for my dishwasher. It is up to you whether you want to merge the PR or not. Denying merge is totally ok for me.

P.S.
Additionally I added the "image" attribute to the `compose.yaml` to be able to build and run different versions of hcpy easily.