### PR TITLE
gh-225 Use valid default_entity_id 

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -124,7 +124,6 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
             "state_topic": state_topic,
             "availability_mode": "all",
             "availability": [{"topic": f"{base_topic}/LWT"}, {"topic": f"{mqtt_topic}/LWT"}],
-            "default_entity_id": f"{device_ident}_{feature_id}",
             "unique_id": f"{device_ident}_{feature_id}",
             "enabled_by_default": not disabled,
         }
@@ -306,6 +305,8 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                         "payload_not_available": "True",
                     }
                 ]
+
+        discovery_payload["default_entity_id"] = f"{component_type}.{discovery_payload['unique_id']}"
 
         discovery_topic = (
             f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{feature_id}/config"

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -306,7 +306,9 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                     }
                 ]
 
-        discovery_payload["default_entity_id"] = f"{component_type}.{discovery_payload['unique_id']}"
+        discovery_payload["default_entity_id"] = (
+            f"{component_type}.{discovery_payload['unique_id']}"
+        )
 
         discovery_topic = (
             f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{feature_id}/config"

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -640,11 +640,13 @@ class TestHADiscovery:
             payload = args[1]
             payload_data = json.loads(payload)
             unique_id = payload_data["unique_id"]
-            object_id = payload_data["default_entity_id"]  # option_id deprecated in HA 2025.10.1
+            entity_id = payload_data["default_entity_id"]  # option_id deprecated in HA 2025.10.1
+            entity_domain = entity_id.split(".")[0]
 
             assert unique_id.startswith("test_oven_")
-            assert object_id.startswith("test_oven_")
-            assert unique_id == object_id
+            assert entity_id.startswith(f"{entity_domain}.test_oven_")
+            assert f"{entity_domain}.{unique_id}" == entity_id
+            assert entity_domain in CONTROL_COMPONENT_TYPES + ["sensor", "binary_sensor", "event"]
 
     def test_discovery_topic_format(self, mock_mqtt_client, sample_discovery_config, devices):
         """Test discovery topic format"""


### PR DESCRIPTION
Use `component_type` as entity domain in `default_entity_id`.

SEE: #225 