### PR TITLE
02/80 as enums

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -124,7 +124,6 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
             "state_topic": state_topic,
             "availability_mode": "all",
             "availability": [{"topic": f"{base_topic}/LWT"}, {"topic": f"{mqtt_topic}/LWT"}],
-            "default_entity_id": f"{device_ident}_{feature_id}",
             "unique_id": f"{device_ident}_{feature_id}",
             "enabled_by_default": not disabled,
         }
@@ -306,6 +305,8 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                         "payload_not_available": "True",
                     }
                 ]
+
+        discovery_payload["default_entity_id"] = f"{component_type}.{discovery_payload['unique_id']}"
 
         discovery_topic = (
             f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{feature_id}/config"

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -306,7 +306,9 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                     }
                 ]
 
-        discovery_payload["default_entity_id"] = f"{component_type}.{discovery_payload['unique_id']}"
+        discovery_payload["default_entity_id"] = (
+            f"{component_type}.{discovery_payload['unique_id']}"
+        )
 
         discovery_topic = (
             f"{HA_DISCOVERY_PREFIX}/{component_type}/hcpy/{device_ident}_{feature_id}/config"

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -254,12 +254,12 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 template = f'[{{"uid":{uid},"value":{{{{value}}}}}}]'
                 discovery_payload["command_template"] = template
 
-                minimum = feature.get("min", None)
-                maximum = feature.get("max", None)
-                if minimum is not None:
-                    discovery_payload["min"] = minimum
-                if maximum is not None:
-                    discovery_payload["max"] = maximum
+                # HA defaults of 1, 100 generally causes warnings for many sensors
+                # Some HC numbers dont supply min/max values
+                # We could go for 2147483647 max int, but the highest seen is
+                # 864000 which is 240 hours.
+                discovery_payload["min"] = feature.get("min", 0)
+                discovery_payload["max"] = feature.get("max", 86400)
                 if step is not None:
                     discovery_payload["step"] = float(step)
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -260,9 +260,9 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 discovery_payload["command_template"] = template
 
                 # Min/Max may be already set for durations above
-                if discovery_payload["min"] is None:
+                if discovery_payload.get("min") is None:
                     discovery_payload["min"] = feature.get("min", None)
-                if discovery_payload["max"] is None:
+                if discovery_payload.get("max") is None:
                     discovery_payload["max"] = feature.get("max", None)
                 if step is not None:
                     discovery_payload["step"] = float(step)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -116,7 +116,6 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
         value = feature.get("value", None)
         values = feature.get("values", None)
         state_topic = f"{mqtt_topic}/state/{feature_id}"
-        step = feature.get("stepSize", None)
 
         discovery_payload = {
             "name": friendly_name,
@@ -181,8 +180,8 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
             # Cooking.Oven.Setting.Cavity.001.AlarmClock doesnt set min/max
             # HA default of 1,100 is too small so warnings raised.
             # Duration often has a min value of 1 but will be set to 0 by device
-            discovery_payload["min"] = 0
-            discovery_payload["max"] = feature.get("max", 86400)
+            discovery_payload["min"] = float(0)
+            discovery_payload["max"] = float(feature.get("max", 86400))
 
         if name == "BSH.Common.Status.ProgramSessionSummary.Latest":
             value_template = "{{ value_json.counter }}"
@@ -260,10 +259,15 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 discovery_payload["command_template"] = template
 
                 # Min/Max may be already set for durations above
-                if discovery_payload.get("min") is None:
-                    discovery_payload["min"] = feature.get("min", None)
-                if discovery_payload.get("max") is None:
-                    discovery_payload["max"] = feature.get("max", None)
+                minimum = feature.get("min", None)
+                if discovery_payload.get("min") is None and minimum is not None:
+                    discovery_payload["min"] = float(minimum)
+
+                maximum = feature.get("max", None)
+                if discovery_payload.get("max") is None and maximum is not None:
+                    discovery_payload["max"] = float(maximum)
+
+                step = feature.get("stepSize", None)
                 if step is not None:
                     discovery_payload["step"] = float(step)
 

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -166,7 +166,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
             discovery_payload["unit_of_measurement"] = "°C"
             discovery_payload["device_class"] = "temperature"
             discovery_payload["icon"] = "mdi:thermometer"
-        elif refCID == "03" and refDID == "80":
+        elif refDID == "80" and (refCID in ("02", "03")) and values is not None:
             if component_type != "event":
                 discovery_payload["device_class"] = "enum"
             discovery_payload["options"] = list(values.values())
@@ -216,6 +216,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
             elif (
                 refCID == "03"
                 and refDID == "80"
+                and values is not None
                 and len(values.values()) == 2
                 and "On" in values.values()
                 and "Off" in values.values()
@@ -228,7 +229,8 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 discovery_payload["payload_on"] = f'[{{"uid":{uid},"value":"On"}}]'
                 discovery_payload["payload_off"] = f'[{{"uid":{uid},"value":"Off"}}]'
                 discovery_payload["device_class"] = "switch"
-            elif refCID == "03" and refDID == "80":
+            # 02/80 can be an enum e.g. Cooking.Oven.Option.Doneness
+            elif refDID == "80" and (refCID in ("02", "03")) and values is not None:
                 component_type = "select"
                 discovery_payload["command_topic"] = f"{mqtt_topic}/set"
                 template = f'[{{"uid":{uid},"value":"{{{{value}}}}"}}]'
@@ -240,6 +242,7 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 or (refCID == "11" and refDID == "A0")
                 or (refCID == "11" and refDID == "80")
                 or (refCID == "14" and refDID == "80")
+                # 02/80 can be a number e.g. Cooking.Oven.Setting.DisplayBrightness
                 or (refCID == "02" and refDID == "80")
                 or (refCID == "81" and refDID == "60")
                 or (refCID == "10" and refDID == "81")

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -178,6 +178,11 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
         ):
             discovery_payload["unit_of_measurement"] = "s"
             discovery_payload["device_class"] = "duration"
+            # Cooking.Oven.Setting.Cavity.001.AlarmClock doesnt set min/max
+            # HA default of 1,100 is too small so warnings raised.
+            # Duration often has a min value of 1 but will be set to 0 by device
+            discovery_payload["min"] = 0
+            discovery_payload["max"] = feature.get("max", 86400)
 
         if name == "BSH.Common.Status.ProgramSessionSummary.Latest":
             value_template = "{{ value_json.counter }}"
@@ -254,12 +259,11 @@ def publish_ha_discovery(discovery_yaml_path, device, client, mqtt_topic, events
                 template = f'[{{"uid":{uid},"value":{{{{value}}}}}}]'
                 discovery_payload["command_template"] = template
 
-                # HA defaults of 1, 100 generally causes warnings for many sensors
-                # Some HC numbers dont supply min/max values
-                # We could go for 2147483647 max int, but the highest seen is
-                # 864000 which is 240 hours.
-                discovery_payload["min"] = feature.get("min", 0)
-                discovery_payload["max"] = feature.get("max", 86400)
+                # Min/Max may be already set for durations above
+                if discovery_payload["min"] is None:
+                    discovery_payload["min"] = feature.get("min", None)
+                if discovery_payload["max"] is None:
+                    discovery_payload["max"] = feature.get("max", None)
                 if step is not None:
                     discovery_payload["step"] = float(step)
 

--- a/discovery.yaml
+++ b/discovery.yaml
@@ -41,6 +41,7 @@ MAGIC_OVERRIDES:
     component_type: "number" 
   Cooking.Oven.Option.SetpointTemperature:
     component_type: "number"  
+    min: 0
   Refrigeration.Common.Status.Door.Freezer:
     icon: mdi:door
   Refrigeration.Common.Status.Door.Refrigerator:

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -640,11 +640,13 @@ class TestHADiscovery:
             payload = args[1]
             payload_data = json.loads(payload)
             unique_id = payload_data["unique_id"]
-            object_id = payload_data["default_entity_id"]  # option_id deprecated in HA 2025.10.1
+            entity_id = payload_data["default_entity_id"]  # option_id deprecated in HA 2025.10.1
+            entity_domain = entity_id.split(".")[0]
 
             assert unique_id.startswith("test_oven_")
-            assert object_id.startswith("test_oven_")
-            assert unique_id == object_id
+            assert entity_id.startswith(f"{entity_domain}.test_oven_")
+            assert f"{entity_domain}.{unique_id}" == entity_id
+            assert entity_domain in CONTROL_COMPONENT_TYPES + ["sensor", "binary_sensor", "event"]
 
     def test_discovery_topic_format(self, mock_mqtt_client, sample_discovery_config, devices):
         """Test discovery topic format"""


### PR DESCRIPTION
Resolves #225 - warnings for durations without min/max set.
Resolves #231 
    02/80 discovered as a number when it is a switch/enum #231
    Allow SetpointTemperature to be 0 to prevent log warnings when set below the specified min value in devices.json