### PR TITLE
Use /ci/services to gate endpoint queries

### DIFF
--- a/HCDevice.py
+++ b/HCDevice.py
@@ -44,7 +44,6 @@ import json
 import re
 import sys
 import threading
-import time
 import traceback
 from base64 import urlsafe_b64encode as base64url_encode
 from datetime import datetime
@@ -67,7 +66,7 @@ class HCDevice:
         self.device_name = "hcpy"
         self.device_id = "0badcafe"
         self.debug = debug
-        self.services_initialized = False
+        self._services_event = threading.Event()
         self.services = {}
         self.token = None
         self.connected = False
@@ -339,10 +338,10 @@ class HCDevice:
 
     # send a message to the device
     def get(self, resource, version=1, action="GET", data=None):
-        if self.services_initialized:
+        if self._services_event.is_set():
             resource_parts = resource.split("/")
             if len(resource_parts) > 1:
-                service = resource.split("/")[1]
+                service = resource_parts[1]
                 if service in self.services.keys():
                     version = self.services[service]["version"]
                 else:
@@ -386,40 +385,31 @@ class HCDevice:
         # Receive initialization message /ei/initialValues
         # Automatically responds in the handle_message function
 
-        # ask the device which services it supports
-        # registered devices gets pushed down too hence the loop
+        # Ask the device which services it supports and wait for the response.
         self.get("/ci/services")
-        while True:
-            time.sleep(1)
-            if self.services_initialized:
-                break
+        if not self._services_event.wait(timeout=10):
+            self.print("timeout waiting for /ci/services, closing connection")
+            self.ws.close()
+            return
 
-        # We override the version based on the registered services received above
-
-        # the clothes washer wants this, the token doesn't matter,
-        # although they do not handle padding characters
-        # they send a response, not sure how to interpet it
-        self.token = base64url_encode(get_random_bytes(32)).decode("UTF-8")
-        self.token = re.sub(r"=", "", self.token)
-        self.get("/ci/authentication", version=2, data={"nonce": self.token})
-
-        self.get("/ci/info")  # clothes washer
-        self.get("/iz/info")  # dish washer
-
-        # Retrieves registered clients like phone/hcpy itself
-        # self.get("/ci/registeredDevices")
-
-        # tzInfo all returns empty?
-        # self.get("/ci/tzInfo")
+        # Gate endpoints based on advertised services (see /ci/services response).
+        # iz-capable devices (ci:3) use /iz/info for device identity.
+        # Non-iz devices (ci:2) use /ci/authentication + /ci/info.
+        if "iz" in self.services:
+            self.get("/iz/info")
+        else:
+            self.token = base64url_encode(get_random_bytes(32)).decode("UTF-8")
+            self.token = re.sub(r"=", "", self.token)
+            self.get("/ci/authentication", version=2, data={"nonce": self.token})
+            self.get("/ci/info")
 
         # We need to send deviceReady for some devices or /ni/ will come back as 403 unauth
         self.get("/ei/deviceReady", version=2, action="NOTIFY")
-        self.get("/ni/info")
-        # self.get("/ni/config", data={"interfaceID": 0})
 
-        # self.get("/ro/allDescriptionChanges")
+        if "ni" in self.services:
+            self.get("/ni/info")
+
         self.get("/ro/allMandatoryValues")
-        self.get("/ro/values")
         self.get("/ro/allDescriptionChanges")
 
     def handle_message(self, buf):
@@ -534,7 +524,7 @@ class HCDevice:
                     self.services[service["service"]] = {
                         "version": service["version"],
                     }
-                self.services_initialized = True
+                self._services_event.set()
 
             elif resource == "/ro/selectedProgram" or resource == "/ro/activeProgram":
                 code = msg.get("code", None)

--- a/HCSocket.py
+++ b/HCSocket.py
@@ -58,6 +58,7 @@ class HCSocket:
             self.host = host
 
         self.psk = base64url(psk64 + "===")
+        self.ws = None
         self.debug = False
 
         if iv64:
@@ -263,6 +264,10 @@ class HCSocket:
         websocket.setdefaulttimeout(30)
 
         self.ws.run_forever(ping_interval=120, ping_timeout=10)
+
+    def close(self):
+        if self.ws:
+            self.ws.close()
 
     # Debug print
     def dprint(self, *args):

--- a/tests/test_HCDevice.py
+++ b/tests/test_HCDevice.py
@@ -1,0 +1,301 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from HCDevice import HCDevice
+
+
+def make_device(services, features=None):
+    """Build an HCDevice with pre-set services, ready to call reconnect().
+
+    Sets the services event so reconnect() proceeds past the wait.
+    Mocks ws.send and ws.close so nothing hits the network.
+    """
+    ws = Mock()
+    device_config = {
+        "name": "TestDevice",
+        "features": features or {},
+    }
+    dev = HCDevice(ws, device_config)
+    dev.session_id = 1
+    dev.tx_msg_id = 1000
+    dev.services = services
+    dev._services_event.set()
+    return dev
+
+
+def sent_resources(device):
+    """Return list of (resource, action) tuples from ws.send calls."""
+    results = []
+    for call in device.ws.send.call_args_list:
+        msg = call.args[0]
+        results.append((msg["resource"], msg["action"]))
+    return results
+
+
+def sent_get_resources(device):
+    """Return list of resource paths that were sent as GETs."""
+    return [r for r, a in sent_resources(device) if a == "GET"]
+
+
+def sent_notify_resources(device):
+    """Return list of resource paths that were sent as NOTIFYs."""
+    return [r for r, a in sent_resources(device) if a == "NOTIFY"]
+
+
+# Service profiles from research captures.
+IZ_SERVICES = {
+    "ci": {"version": 3},
+    "ei": {"version": 2},
+    "iz": {"version": 1},
+    "ni": {"version": 1},
+    "ro": {"version": 1},
+}
+
+# Same as IZ_SERVICES but with iz version bumped so the version override
+# test is meaningful (default version param in get() is 1, so version 1
+# passes whether or not the override fires).
+IZ_SERVICES_V2 = {
+    **IZ_SERVICES,
+    "iz": {"version": 2},
+}
+
+NON_IZ_SERVICES = {
+    "ro": {"version": 1},
+    "ei": {"version": 2},
+    "ci": {"version": 2},
+    "ni": {"version": 1},
+}
+
+
+@patch("HCDevice.HCDevice.print")
+class TestReconnectIzCapable:
+    """iz-capable devices (ci:3): use /iz/info, skip auth and /ci/info."""
+
+    def test_queries_iz_info(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/iz/info" in sent_get_resources(dev)
+
+    def test_skips_ci_info(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/ci/info" not in sent_get_resources(dev)
+
+    def test_skips_ci_authentication(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/ci/authentication" not in sent_get_resources(dev)
+
+    def test_queries_ni_info(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/ni/info" in sent_get_resources(dev)
+
+    def test_sends_device_ready(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/ei/deviceReady" in sent_notify_resources(dev)
+
+    def test_queries_all_mandatory_values(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/ro/allMandatoryValues" in sent_get_resources(dev)
+
+    def test_queries_all_description_changes(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        assert "/ro/allDescriptionChanges" in sent_get_resources(dev)
+
+
+@patch("HCDevice.HCDevice.print")
+class TestReconnectNonIz:
+    """Non-iz devices (ci:2): use /ci/authentication + /ci/info, skip /iz/info."""
+
+    def test_queries_ci_authentication(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        assert "/ci/authentication" in sent_get_resources(dev)
+
+    def test_queries_ci_info(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        assert "/ci/info" in sent_get_resources(dev)
+
+    def test_skips_iz_info(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        assert "/iz/info" not in sent_get_resources(dev)
+
+    def test_auth_before_ci_info(self, _print):
+        """Auth nonce must be sent before /ci/info."""
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        gets = sent_get_resources(dev)
+        auth_idx = gets.index("/ci/authentication")
+        info_idx = gets.index("/ci/info")
+        assert auth_idx < info_idx
+
+    def test_queries_ni_info(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        assert "/ni/info" in sent_get_resources(dev)
+
+    def test_sends_device_ready(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        assert "/ei/deviceReady" in sent_notify_resources(dev)
+
+
+@patch("HCDevice.HCDevice.print")
+class TestReconnectNoNi:
+    """Device without ni service should skip /ni/info."""
+
+    def test_skips_ni_info(self, _print):
+        services = {
+            "ci": {"version": 3},
+            "ei": {"version": 2},
+            "iz": {"version": 1},
+            "ro": {"version": 1},
+        }
+        dev = make_device(services)
+        dev.reconnect()
+        assert "/ni/info" not in sent_get_resources(dev)
+
+
+@patch("HCDevice.HCDevice.print")
+class TestReconnectRoValues:
+    """/ro/values should never be queried during reconnect."""
+
+    def test_ro_values_not_queried_iz(self, _print):
+        dev = make_device(IZ_SERVICES)
+        dev.reconnect()
+        gets = sent_get_resources(dev)
+        assert len(gets) > 1
+        assert "/ro/values" not in gets
+
+    def test_ro_values_not_queried_non_iz(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        gets = sent_get_resources(dev)
+        assert len(gets) > 1
+        assert "/ro/values" not in gets
+
+
+@patch("HCDevice.HCDevice.print")
+class TestReconnectTimeout:
+    """When /ci/services never arrives, reconnect should close and return."""
+
+    def test_closes_websocket_on_timeout(self, _print):
+        ws = Mock()
+        dev = HCDevice(ws, {"name": "TestDevice", "features": {}})
+        dev.session_id = 1
+        dev.tx_msg_id = 1000
+        # Do not set the event, so wait() will time out.
+        dev._services_event.wait = Mock(return_value=False)
+
+        dev.reconnect()
+
+        ws.close.assert_called_once()
+
+    def test_no_post_discovery_requests_on_timeout(self, _print):
+        ws = Mock()
+        dev = HCDevice(ws, {"name": "TestDevice", "features": {}})
+        dev.session_id = 1
+        dev.tx_msg_id = 1000
+        dev._services_event.wait = Mock(return_value=False)
+
+        dev.reconnect()
+
+        # Only /ci/services should have been sent (before the wait).
+        resources = sent_get_resources(dev)
+        assert resources == ["/ci/services"]
+
+
+@patch("HCDevice.HCDevice.print")
+class TestReconnectVersionOverride:
+    """Services versions should be used in requests."""
+
+    def test_iz_info_uses_iz_version(self, _print):
+        dev = make_device(IZ_SERVICES_V2)
+        dev.reconnect()
+        for call in dev.ws.send.call_args_list:
+            msg = call.args[0]
+            if msg["resource"] == "/iz/info":
+                assert msg["version"] == 2
+                return
+        pytest.fail("/iz/info not found in sent messages")
+
+    def test_ci_info_uses_ci_version(self, _print):
+        dev = make_device(NON_IZ_SERVICES)
+        dev.reconnect()
+        for call in dev.ws.send.call_args_list:
+            msg = call.args[0]
+            if msg["resource"] == "/ci/info":
+                assert msg["version"] == 2
+                return
+        pytest.fail("/ci/info not found in sent messages")
+
+
+@patch("HCDevice.HCDevice.print")
+class TestServicesEvent:
+    """The /ci/services response handler should set the event."""
+
+    def test_event_set_on_services_response(self, _print):
+        ws = Mock()
+        dev = HCDevice(ws, {"name": "TestDevice", "features": {}})
+        dev.session_id = 1
+        dev.tx_msg_id = 1000
+
+        assert not dev._services_event.is_set()
+
+        import json
+
+        msg = json.dumps(
+            {
+                "sID": 1,
+                "msgID": 1000,
+                "resource": "/ci/services",
+                "version": 1,
+                "action": "RESPONSE",
+                "data": [
+                    {"service": "ci", "version": 3},
+                    {"service": "ei", "version": 2},
+                    {"service": "iz", "version": 1},
+                    {"service": "ro", "version": 1},
+                ],
+            }
+        )
+        dev.handle_message(msg)
+
+        assert dev._services_event.is_set()
+        assert "ci" in dev.services
+        assert "iz" in dev.services
+
+    def test_services_populated_from_response(self, _print):
+        ws = Mock()
+        dev = HCDevice(ws, {"name": "TestDevice", "features": {}})
+        dev.session_id = 1
+        dev.tx_msg_id = 1000
+
+        import json
+
+        msg = json.dumps(
+            {
+                "sID": 1,
+                "msgID": 1000,
+                "resource": "/ci/services",
+                "version": 1,
+                "action": "RESPONSE",
+                "data": [
+                    {"service": "ro", "version": 1},
+                    {"service": "ci", "version": 2},
+                ],
+            }
+        )
+        dev.handle_message(msg)
+
+        assert dev.services == {
+            "ro": {"version": 1},
+            "ci": {"version": 2},
+        }


### PR DESCRIPTION
Previously, reconnect queried all endpoints unconditionally after  fetching /ci/services, ignoring the response. This caused error  responses (400/404) from devices that don't support certain endpoints, which got published to MQTT as state.

Now reconnect uses the services list to decide what to query:

- iz in services: GET /iz/info (skip auth and /ci/info)
- iz absent: GET /ci/authentication + /ci/info
- ni in services: GET /ni/info

The time.sleep(1) poll loop was replaced with threading.Event.wait (timeout=10) on /ci/services. On timeout, the websocket is closed so  client_connect retries the connection.

The GET /ro/values call was also dropped since the HC app never sends it (verified across 7 device captures) and all tested devices return 400. The error was being published as device state. This was added in 1298992 ("get initial values for all devices") but doesn't appear to do anything useful. The /ro/allMandatoryValues endpoint provides initial state, and /ro/values NOTIFYs push changes.

This PR is stacked on top of ~~hcpy2-0/hcpy#238~~ `main` (realized it didn't need the previous work).