### PR TITLE
Reset ProgramPhase when OperationState becomes terminal (#261)

### DIFF
--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -23,6 +23,7 @@ SENTINEL = object()
 _TERMINAL_OP_STATES = {"Ready", "Inactive", "Finished", "Error", "Aborting"}
 _OP_STATE_KEY = "BSH.Common.Status.OperationState"
 
+
 def hcprint(*args):
     print(now(), *args, flush=True)
 
@@ -56,17 +57,19 @@ def handle_device_message(msg, mydevice, published_state, client, mqtt_topic, na
         old_published = published_state.get(key, SENTINEL)
         if val != old_published:
             changed[key] = val
-            
+
     # Issue #261: devices don't send ProgramPhase=None on program end.
     # Reset it manually when OperationState becomes terminal.
     if _OP_STATE_KEY in changed and changed[_OP_STATE_KEY] in _TERMINAL_OP_STATES:
         for k in list(mydevice.state.keys()):
             if k.endswith(".Status.ProgramPhase") and mydevice.state[k] not in (None, "None"):
                 if debug:
-                    hcprint(name, f"resetting {k} to None (OperationState -> {changed[_OP_STATE_KEY]})")
+                    hcprint(
+                        name, f"resetting {k} to None (OperationState -> {changed[_OP_STATE_KEY]})"
+                    )
                 mydevice.state[k] = "None"
                 changed[k] = "None"
-                
+
     if not changed and not events:
         return
 

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -19,6 +19,9 @@ from utils import clean_international_text, now
 
 SENTINEL = object()
 
+# Terminal OperationStates that trigger a ProgramPhase reset (issue #261).
+_TERMINAL_OP_STATES = {"Ready", "Inactive", "Finished"}
+_OP_STATE_KEY = "BSH.Common.Status.OperationState"
 
 def hcprint(*args):
     print(now(), *args, flush=True)
@@ -53,7 +56,17 @@ def handle_device_message(msg, mydevice, published_state, client, mqtt_topic, na
         old_published = published_state.get(key, SENTINEL)
         if val != old_published:
             changed[key] = val
-
+            
+    # Issue #261: devices don't send ProgramPhase=None on program end.
+    # Reset it manually when OperationState becomes terminal.
+    if _OP_STATE_KEY in changed and changed[_OP_STATE_KEY] in _TERMINAL_OP_STATES:
+        for k in list(mydevice.state.keys()):
+            if k.endswith(".Status.ProgramPhase") and mydevice.state[k] not in (None, "None"):
+                if debug:
+                    hcprint(name, f"resetting {k} to None (OperationState -> {changed[_OP_STATE_KEY]})")
+                mydevice.state[k] = "None"
+                changed[k] = "None"
+                
     if not changed and not events:
         return
 

--- a/hc2mqtt.py
+++ b/hc2mqtt.py
@@ -20,7 +20,7 @@ from utils import clean_international_text, now
 SENTINEL = object()
 
 # Terminal OperationStates that trigger a ProgramPhase reset (issue #261).
-_TERMINAL_OP_STATES = {"Ready", "Inactive", "Finished"}
+_TERMINAL_OP_STATES = {"Ready", "Inactive", "Finished", "Error", "Aborting"}
 _OP_STATE_KEY = "BSH.Common.Status.OperationState"
 
 def hcprint(*args):


### PR DESCRIPTION
Fixes #261 - devices don't send ProgramPhase=None on program end, so the retained MQTT value stays frozen.

Tested on **Siemens SX63HX52BE**

**First test: Normal program end (Quick45)**

Device sent `OperationState=Finished` without a ProgramPhase key. The patch detects this and resets ProgramPhase to `None`.

```
dishwasher {'BSH.Common.Status.OperationState': 'Finished'}
dishwasher resetting Dishcare.Dishwasher.Status.ProgramPhase to None (OperationState > Finished)
dishwasher publishing 2 changed keys: {"BSH.Common.Status.OperationState": "Finished", "Dishcare.Dishwasher.Status.ProgramPhase": "None"}

dishwasher {'BSH.Common.Status.OperationState': 'Ready'}
dishwasher publishing 1 changed keys: {"BSH.Common.Status.OperationState": "Ready"}
```

ProgramPhase cleared on `Finished`. When `Ready` follows, ProgramPhase is already `None` so nothing is published again. 



**Second test: Manual abort (Standard 60C, ProgramPhase was `PreRinse`)**

Program aborted via IOS HC app. Device sent `OperationState=Aborting` without a ProgramPhase key.Same as above.

```
dishwasher {'BSH.Common.Event.ProgramAborted': 'Present'}

dishwasher {'BSH.Common.Status.OperationState': 'Aborting'}
dishwasher resetting Dishcare.Dishwasher.Status.ProgramPhase to None (OperationState > Aborting)
dishwasher publishing 2 changed keys: {"BSH.Common.Status.OperationState": "Aborting", "Dishcare.Dishwasher.Status.ProgramPhase": "None"}

dishwasher {'BSH.Common.Status.OperationState': 'Ready'}
dishwasher publishing 1 changed keys: {"BSH.Common.Status.OperationState": "Ready"}
```


