### PR TITLE
Oven improvements: real °C temperature mapping, per-event ack buttons, steam program select, creature comforts

### DIFF
--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -196,31 +196,39 @@ def publish_ha_discovery(
         # true -- ovens silently ignore {"uid":6,"value":true} (upstream hcpy
         # issue #270). The mature homeconnect_websocket lib acknowledges via
         # Command.execute(self._uid), i.e. {"uid":6,"value":<event_uid>}.
-        # Publish one button per event feature so each carries its event uid.
+        # Publish ONE select per device listing the event features; the command
+        # template extracts the event uid from the chosen option, keeping HA's
+        # UI to a single dropdown instead of one button per event.
         if (
             name == "BSH.Common.Command.AcknowledgeEvent"
             and uid is not None
             and override_component_type is None
         ):
+            event_options = []
             for event_feature in ADDITIONAL_FEATURES + list(device["features"].values()):
                 event_name = event_feature.get("name", "")
                 event_uid = event_feature.get("uid", None)
                 if "Event." not in event_name or event_uid is None:
                     continue
                 event_friendly = event_name.split(".")[-1]
-                event_feature_id = event_name.lower().replace(".", "_")
+                event_options.append(f"{event_friendly} ({event_uid})")
+            if event_options:
                 ack_payload = {
-                    "name": f"{friendly_name} {event_friendly}",
+                    "name": friendly_name,
                     "device": device_info,
                     "availability_mode": "all",
                     "availability": [
                         {"topic": f"{base_topic}/LWT"},
                         {"topic": f"{mqtt_topic}/LWT"},
                     ],
-                    "unique_id": f"{device_ident}_acknowledge_{event_feature_id}",
+                    "unique_id": f"{device_ident}_acknowledgeevent",
                     "enabled_by_default": True,
                     "command_topic": f"{mqtt_topic}/set",
-                    "payload_press": f'[{{"uid":{uid},"value":{event_uid}}}]',
+                    "options": event_options,
+                    # extract the trailing "(<uid>)" from the option label
+                    "command_template": (
+                        '[{"uid":6,"value":{{ value.split(" (")[1] ' '| replace(")", "") }}}]'
+                    ),
                 }
                 if local_control_lockout:
                     ack_payload["availability"] = ack_payload["availability"] + [
@@ -231,8 +239,7 @@ def publish_ha_discovery(
                         }
                     ]
                 ack_topic = clean_international_text(
-                    f"{HA_DISCOVERY_PREFIX}/button/hcpy/"
-                    f"{device_ident}_acknowledge_{event_feature_id}/config"
+                    f"{HA_DISCOVERY_PREFIX}/select/hcpy/" f"{device_ident}_acknowledgeevent/config"
                 )
                 client.publish(ack_topic, json.dumps(ack_payload), retain=True)
             continue

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -183,6 +183,15 @@ def publish_ha_discovery(
         if overrides:
             override_component_type = overrides.get("component_type", None)
 
+        # Event features can additionally publish a binary_sensor that mirrors the
+        # event state (Present -> ON, Off -> OFF) WITHOUT replacing the event
+        # entity -- automations may depend on the event entity itself.
+        additive_binary = False
+        if overrides and overrides.get("additive_binary_sensor", False):
+            additive_binary = True
+
+        is_event_feature = False
+
         # AcknowledgeEvent (uid 6) must carry the EVENT's uid as its value, not
         # true -- ovens silently ignore {"uid":6,"value":true} (upstream hcpy
         # issue #270). The mature homeconnect_websocket lib acknowledges via
@@ -245,6 +254,7 @@ def publish_ha_discovery(
                 discovery_payload.pop("value_template", None)
                 discovery_payload.pop("options", None)
             discovery_payload["state_topic"] = f"{mqtt_topic}/event/{feature_id}"
+            is_event_feature = True
         else:
             component_type = "sensor"
 
@@ -423,10 +433,54 @@ def publish_ha_discovery(
         )
 
         if overrides:
-            # Overwrite keys with override values
+            # Overwrite keys with override values. The additive_binary_sensor
+            # control key and its binary-sensor-only config belong to the
+            # additive binary sensor, not to the primary entity payload.
             for k, v in overrides.items():
+                if k in ("additive_binary_sensor", "additive_binary_sensor_config"):
+                    continue
                 if isinstance(v, str):
-                    overrides[k] = v.replace("DEVICE_NAME", device_ident)
-            discovery_payload = discovery_payload | overrides
+                    v = v.replace("DEVICE_NAME", device_ident)
+                    overrides[k] = v
+            discovery_payload = discovery_payload | {
+                k: v
+                for k, v in overrides.items()
+                if k not in ("additive_binary_sensor", "additive_binary_sensor_config")
+            }
 
         client.publish(discovery_topic, json.dumps(discovery_payload), retain=True)
+
+        # Additive binary_sensor: mirror an event feature (Present -> ON,
+        # Off -> OFF) as a binary_sensor WITHOUT replacing the event entity.
+        if additive_binary and is_event_feature:
+            binary_payload = {
+                "name": f"{friendly_name} Active",
+                "device": device_info,
+                "state_topic": f"{mqtt_topic}/event/{feature_id}",
+                "value_template": "{{ 'ON' if value_json.event_type == 'Present' else 'OFF' }}",
+                "payload_on": "ON",
+                "payload_off": "OFF",
+                "availability_mode": "all",
+                "availability": [{"topic": f"{base_topic}/LWT"}, {"topic": f"{mqtt_topic}/LWT"}],
+                "unique_id": f"{device_ident}_{feature_id}_active",
+                "enabled_by_default": not disabled,
+                "default_entity_id": f"binary_sensor.{device_ident}_{feature_id}_active",
+            }
+            if overrides:
+                for k, v in overrides.items():
+                    if k in ("component_type", "additive_binary_sensor", "additive_binary_sensor_config"):
+                        continue
+                    if isinstance(v, str):
+                        v = v.replace("DEVICE_NAME", device_ident)
+                    binary_payload[k] = v
+                additive_config = overrides.get("additive_binary_sensor_config", None)
+                if additive_config:
+                    for k, v in additive_config.items():
+                        if isinstance(v, str):
+                            v = v.replace("DEVICE_NAME", device_ident)
+                        binary_payload[k] = v
+            binary_topic = clean_international_text(
+                f"{HA_DISCOVERY_PREFIX}/binary_sensor/hcpy/"
+                f"{device_ident}_{feature_id}_active/config"
+            )
+            client.publish(binary_topic, json.dumps(binary_payload), retain=True)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -476,7 +476,11 @@ def publish_ha_discovery(
             }
             if overrides:
                 for k, v in overrides.items():
-                    if k in ("component_type", "additive_binary_sensor", "additive_binary_sensor_config"):
+                    if k in (
+                        "component_type",
+                        "additive_binary_sensor",
+                        "additive_binary_sensor_config",
+                    ):
                         continue
                     if isinstance(v, str):
                         v = v.replace("DEVICE_NAME", device_ident)

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -183,6 +183,51 @@ def publish_ha_discovery(
         if overrides:
             override_component_type = overrides.get("component_type", None)
 
+        # AcknowledgeEvent (uid 6) must carry the EVENT's uid as its value, not
+        # true -- ovens silently ignore {"uid":6,"value":true} (upstream hcpy
+        # issue #270). The mature homeconnect_websocket lib acknowledges via
+        # Command.execute(self._uid), i.e. {"uid":6,"value":<event_uid>}.
+        # Publish one button per event feature so each carries its event uid.
+        if (
+            name == "BSH.Common.Command.AcknowledgeEvent"
+            and uid is not None
+            and override_component_type is None
+        ):
+            for event_feature in ADDITIONAL_FEATURES + list(device["features"].values()):
+                event_name = event_feature.get("name", "")
+                event_uid = event_feature.get("uid", None)
+                if "Event." not in event_name or event_uid is None:
+                    continue
+                event_friendly = event_name.split(".")[-1]
+                event_feature_id = event_name.lower().replace(".", "_")
+                ack_payload = {
+                    "name": f"{friendly_name} {event_friendly}",
+                    "device": device_info,
+                    "availability_mode": "all",
+                    "availability": [
+                        {"topic": f"{base_topic}/LWT"},
+                        {"topic": f"{mqtt_topic}/LWT"},
+                    ],
+                    "unique_id": f"{device_ident}_acknowledge_{event_feature_id}",
+                    "enabled_by_default": True,
+                    "command_topic": f"{mqtt_topic}/set",
+                    "payload_press": f'[{{"uid":{uid},"value":{event_uid}}}]',
+                }
+                if local_control_lockout:
+                    ack_payload["availability"] = ack_payload["availability"] + [
+                        {
+                            "topic": f"{mqtt_topic}/state/bsh_common_status_localcontrolactive",
+                            "payload_available": "False",
+                            "payload_not_available": "True",
+                        }
+                    ]
+                ack_topic = clean_international_text(
+                    f"{HA_DISCOVERY_PREFIX}/button/hcpy/"
+                    f"{device_ident}_acknowledge_{event_feature_id}/config"
+                )
+                client.publish(ack_topic, json.dumps(ack_payload), retain=True)
+            continue
+
         if (
             refCID == "01" and (refDID == "00" or refDID == "01")
         ) or override_component_type == "binary_sensor":
@@ -239,7 +284,8 @@ def publish_ha_discovery(
         ) or override_component_type in CONTROL_COMPONENT_TYPES:
             # 01/00 is binary true/false
             # 01/01 is binary true/false only seen for Cooking.Common.Setting.ButtonTones
-            # 15/81 is accept/reject event - maybe it needs the event ID rather than true/false?
+            # 15/81 accept/reject commands: AcknowledgeEvent is special-cased above
+            # to publish one button per event carrying the event uid
             if (
                 (refCID == "01" and (refDID == "00" or refDID == "01"))
                 or (refCID == "15" and refDID == "81")

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -259,8 +259,16 @@ def publish_ha_discovery(
             component_type = "sensor"
 
         # Temperature
-        if refCID == "07" and (refDID == "A4" or refDID == "A1"):
+        # 07/A1|A4 = °C setpoints/reads (SetpointTemperature, MeatProbeTemperature,
+        # CurrentMeatprobeTemperature); 07/81 = °C read-only sensor
+        # (CurrentCavityTemperature); 08/A1|81 = °F variants
+        # (SetpointTemperatureFahrenheit, Current*TemperatureFahrenheit).
+        if refCID == "07" and (refDID in ("A1", "A4", "81")):
             discovery_payload["unit_of_measurement"] = "°C"
+            discovery_payload["device_class"] = "temperature"
+            discovery_payload["icon"] = "mdi:thermometer"
+        elif refCID == "08" and (refDID in ("A1", "81")):
+            discovery_payload["unit_of_measurement"] = "°F"
             discovery_payload["device_class"] = "temperature"
             discovery_payload["icon"] = "mdi:thermometer"
         elif refDID == "80" and (refCID in ("02", "03")) and values is not None:

--- a/HADiscovery.py
+++ b/HADiscovery.py
@@ -347,6 +347,13 @@ def publish_ha_discovery(
                 template = f'[{{"uid":{uid},"value":{{{{value}}}}}}]'
                 discovery_payload["command_template"] = template
 
+                # Temperature numbers (07/A1|A4, e.g. Cooking.Oven.Option.SetpointTemperature)
+                # mirror the sensor branch: carry °C + temperature device class.
+                if refCID == "07" and (refDID == "A1" or refDID == "A4"):
+                    discovery_payload["device_class"] = "temperature"
+                    discovery_payload["unit_of_measurement"] = "°C"
+                    discovery_payload["icon"] = "mdi:thermometer"
+
                 # Min/Max may be already set for durations above
                 minimum = feature.get("min", None)
                 if discovery_payload.get("min") is None and minimum is not None:

--- a/README.md
+++ b/README.md
@@ -500,3 +500,37 @@ MQTT auto-discovery messages. With `ha_discovery = True` in `config.ini` or by
 passing `--ha-discovery` on the commandline, `hcpy` will publish
 [HA discovery messages](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)
 for each recognised property of your devices.
+
+### Duration semantics (SECONDS, not minutes)
+
+`BSH.Common.Option.Duration` and the `*ProgramTime` options
+(`RemainingProgramTime`, `ElapsedProgramTime`, `StartInRelative`) are published
+as seconds on the wire and in discovery:
+
+- `unit_of_measurement: s` with `device_class: duration` on the HA entity.
+- The number entity bounds come from the DeviceDescription XML: e.g. the
+  Gaggenau BOP251102/BSP250101 `Duration` feature has `min=0`, `max=266400`
+  (= 74 hours in seconds) and default `60` (= 1 minute in seconds).
+- Never reinterpret these as minutes. A `{"uid": 548, "value": 60}` payload
+  sets a 60-second timer, not 60 minutes.
+
+This keeps the existing BOP251102 oven entities unchanged (still seconds).
+
+### Additive binary sensors from events
+
+Event features can additionally publish a `binary_sensor` that mirrors the
+event state (`Present` -> ON, `Off` -> OFF) *without* replacing the event
+entity. Enable it per feature in `discovery.yaml`:
+
+```yaml
+MAGIC_OVERRIDES:
+  Cooking.Common.Event.ApplianceModuleError:
+    additive_binary_sensor: true
+    additive_binary_sensor_config:
+      device_class: problem
+      icon: mdi:alert
+```
+
+The event entity (e.g. `event.<dev>_cooking_common_event_appliancemoduleerror`)
+is still published; the extra `binary_sensor` gets unique_id suffix `_active`
+and watches the same `/event/<feature>` state topic.

--- a/discovery.yaml
+++ b/discovery.yaml
@@ -6,11 +6,24 @@ MAGIC_OVERRIDES:
   BSH.Common.Option.RemainingProgramTime:
     device_class: duration
     unit_of_measurement: s
+  # BSH.Common.Option.Duration (and all *ProgramTime options) are SECONDS on the
+  # wire -- max 266400 = 74 h in seconds, default 60 = 1 minute. The 10/82 number
+  # branch below keeps unit_of_measurement: s and device_class: duration; never
+  # reinterpret these as minutes. Verified against the Gaggenau BOP251102 oven
+  # (existing oven Duration number entity stays in seconds).
+  Cooking.Common.Event.ApplianceModuleError:
+    additive_binary_sensor: true
+    additive_binary_sensor_config:
+      device_class: problem
+      icon: mdi:alert
   BSH.Common.Option.StartInRelative:
     device_class: duration
     unit_of_measurement: s
   BSH.Common.Status.DoorState:
     icon: mdi:door
+  BSH.Common.Status.RemoteControlStartAllowed:
+    component_type: "binary_sensor"
+    icon: mdi:play
   BSH.Common.Status.Program.All.Count.Started:
     state_class: total_increasing
   BSH.Common.Setting.PowerState:

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -210,6 +210,81 @@ class TestHADiscovery:
         assert setpoint_payload["max"] == 250.0
         assert setpoint_payload["step"] == 5.0
 
+    def test_current_cavity_temperature_sensor_is_celsius(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """CurrentCavityTemperature (07/81 read) must publish as a °C temperature
+        sensor -- not the unitless number it used to be (Gaggenau BSP250101/BOP251102)."""
+        device = {
+            "name": "test_oven",
+            "features": {
+                "4096": {
+                    "name": "Cooking.Oven.Status.CurrentCavityTemperature",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "07",
+                    "refDID": "81",
+                },
+            },
+        }
+        mqtt_topic = "test/device/oven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        payload = None
+        for call in mock_mqtt_client.publish.call_args_list:
+            topic = call[0][0]
+            if "sensor" in topic and "currentcavitytemperature" in topic:
+                payload = json.loads(call[0][1])
+        assert payload is not None, "CurrentCavityTemperature sensor topic not published"
+        assert payload["device_class"] == "temperature"
+        assert payload["unit_of_measurement"] == "°C"
+        assert payload["icon"] == "mdi:thermometer"
+
+    def test_fahrenheit_temperature_sensors_carry_f(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """°F variants (08/81, 08/A1) must publish as temperature sensors with °F."""
+        device = {
+            "name": "test_oven",
+            "features": {
+                "4103": {
+                    "name": "Cooking.Oven.Status.CurrentCavityTemperatureFahrenheit",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "08",
+                    "refDID": "81",
+                },
+                "5130": {
+                    "name": "Cooking.Oven.Option.SetpointTemperatureFahrenheit",
+                    "access": "readWrite",
+                    "available": "true",
+                    "refCID": "08",
+                    "refDID": "A1",
+                },
+            },
+        }
+        mqtt_topic = "test/device/oven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        found = {}
+        for call in mock_mqtt_client.publish.call_args_list:
+            topic = call[0][0]
+            if "sensor" in topic and "fahrenheit" in topic:
+                found[topic] = json.loads(call[0][1])
+        assert len(found) == 2, "expected 2 fahrenheit sensor topics, got %r" % list(found)
+        for topic, payload in found.items():
+            assert payload["device_class"] == "temperature", topic
+            assert payload["unit_of_measurement"] == "°F", topic
+            assert payload["icon"] == "mdi:thermometer", topic
+
     def test_select_component_detection(
         self, mock_mqtt_client, sample_discovery_config, devices, device_state
     ):

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -714,11 +714,12 @@ class TestHADiscovery:
 
         assert button_found, "Button component should be detected for writeonly features"
 
-    def test_acknowledge_event_buttons_carry_event_uid(
+    def test_acknowledge_event_select_carries_event_uid(
         self, mock_mqtt_client, sample_discovery_config, device_state
     ):
-        """AcknowledgeEvent must publish one button per event
-        carrying the event uid (issue #270)."""
+        """AcknowledgeEvent must publish ONE select per device whose options
+        carry the event uid, rendered by a command template into the
+        per-event ack payload (issue #270)."""
         device = {
             "name": "test_device",
             "features": {
@@ -760,29 +761,40 @@ class TestHADiscovery:
             )
 
         calls = mock_mqtt_client.publish.call_args_list
-        expected = {
-            "_acknowledge_bsh_common_event_programfinished": '[{"uid":6,"value":540}]',
-            "_acknowledge_cooking_oven_event_watercontainerempty": '[{"uid":6,"value":4611}]',
-        }
-        found = {}
+        ack_select = None
         abort_payloads = []
         for call in calls:
             args = call[0]
             topic = args[0]
-            if "button" not in topic:
-                continue
-            payload_data = json.loads(args[1])
-            if "acknowledge" in topic:
-                for marker, payload in expected.items():
-                    if marker in topic:
-                        found[marker] = payload_data
+            if "select/hcpy/test_device_acknowledgeevent" in topic:
+                ack_select = json.loads(args[1])
             if "abortprogram" in topic:
-                abort_payloads.append(payload_data)
+                abort_payloads.append(json.loads(args[1]))
 
-        for marker, payload in expected.items():
-            assert marker in found, f"Missing per-event ack button for {marker}"
-            assert found[marker]["payload_press"] == payload
-            assert found[marker]["command_topic"] == f"{mqtt_topic}/set"
+        assert ack_select is not None, "Missing single AcknowledgeEvent select"
+        assert ack_select["command_topic"] == f"{mqtt_topic}/set"
+        assert ack_select["options"] == [
+            "ProgramFinished (540)",
+            "WaterContainerEmpty (4611)",
+        ]
+        # command template must render the option label back to the event uid
+        tmpl = ack_select["command_template"]
+        for opt, expected_uid in [
+            ("ProgramFinished (540)", 540),
+            ("WaterContainerEmpty (4611)", 4611),
+        ]:
+            label = opt.split(" (")[1].replace(")", "")
+            rendered = tmpl.replace('{{ value.split(" (")[1] | replace(")", "") }}', label)
+            assert (
+                rendered == f'[{{"uid":6,"value":{expected_uid}}}]'
+            ), f"command template must render {opt} to uid {expected_uid}"
+
+        # No per-event ack buttons should be published anymore
+        for call in calls:
+            args = call[0]
+            topic = args[0]
+            if "button" in topic and "acknowledge" in topic:
+                raise AssertionError(f"Unexpected per-event ack button: {topic}")
 
         # No generic AcknowledgeEvent button with the broken hardcoded true
         for call in calls:
@@ -1006,8 +1018,7 @@ class TestHADiscovery:
         self, mock_mqtt_client, sample_discovery_config, device_state
     ):
         """The four named oven events must surface as event entities with event_types
-        and state topics on the /event/ path, with per-event ack buttons carrying the
-        event uid (per-event ack fix)."""
+        and state topics on the /event/ path (per-event ack fix)."""
         device = {
             "name": "test_soven",
             "features": {

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -182,6 +182,34 @@ class TestHADiscovery:
 
         assert number_found, "Number component should be detected for numeric features"
 
+    def test_setpoint_temperature_number_is_celsius(
+        self, mock_mqtt_client, sample_discovery_config, devices, device_state
+    ):
+        """Setpoint temperature number must carry °C + temperature device class + bounds"""
+        device = devices[0]
+        mqtt_topic = "test/device/oven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        calls = mock_mqtt_client.publish.call_args_list
+        setpoint_payload = None
+        for call in calls:
+            args = call[0]
+            topic = args[0]
+            if "number" in topic and "setpointtemperature" in topic:
+                setpoint_payload = json.loads(args[1])
+
+        assert setpoint_payload is not None, "setpoint temperature number topic not published"
+        assert setpoint_payload["device_class"] == "temperature"
+        assert setpoint_payload["unit_of_measurement"] == "°C"
+        assert setpoint_payload["icon"] == "mdi:thermometer"
+        assert setpoint_payload["min"] == 30.0
+        assert setpoint_payload["max"] == 250.0
+        assert setpoint_payload["step"] == 5.0
+
     def test_select_component_detection(
         self, mock_mqtt_client, sample_discovery_config, devices, device_state
     ):

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -717,7 +717,8 @@ class TestHADiscovery:
     def test_acknowledge_event_buttons_carry_event_uid(
         self, mock_mqtt_client, sample_discovery_config, device_state
     ):
-        """AcknowledgeEvent must publish one button per event carrying the event uid (issue #270)."""
+        """AcknowledgeEvent must publish one button per event
+        carrying the event uid (issue #270)."""
         device = {
             "name": "test_device",
             "features": {
@@ -1056,8 +1057,12 @@ class TestHADiscovery:
         expected = {
             "test_soven_bsh_common_event_programfinished": "BSH.Common.Event.ProgramFinished",
             "test_soven_bsh_common_event_programaborted": "BSH.Common.Event.ProgramAborted",
-            "test_soven_cooking_common_event_preheatfinished": "Cooking.Common.Event.PreheatFinished",
-            "test_soven_cooking_oven_event_watercontainerempty": "Cooking.Oven.Event.WaterContainerEmpty",
+            "test_soven_cooking_common_event_preheatfinished": (
+                "Cooking.Common.Event.PreheatFinished"
+            ),
+            "test_soven_cooking_oven_event_watercontainerempty": (
+                "Cooking.Oven.Event.WaterContainerEmpty"
+            ),
         }
         for marker, name in expected.items():
             assert marker in events, f"Missing event entity {name}"
@@ -1149,7 +1154,10 @@ class TestHADiscovery:
         event_topic = (
             "homeassistant/event/hcpy/test_soven_cooking_common_event_appliancemoduleerror/config"
         )
-        binary_topic = "homeassistant/binary_sensor/hcpy/test_soven_cooking_common_event_appliancemoduleerror_active/config"
+        binary_topic = (
+            "homeassistant/binary_sensor/hcpy/"
+            "test_soven_cooking_common_event_appliancemoduleerror_active/config"
+        )
 
         # Event entity still published (watchdog automations depend on it)
         assert event_topic in topics

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -844,5 +844,70 @@ class TestHADiscovery:
         assert CONTROL_COMPONENT_TYPES == expected_types
 
 
+
+    def test_soven_steam_program_select_options(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """ActiveProgram/SelectedProgram select options are built from Cooking.Oven.Program.* names
+        and command topics/templates wire {"program":"<name>","options":[...]} correctly."""
+        device = {
+            "name": "test_soven",
+            "description": {"brand": "GAGGENAU", "model": "BSP250101", "version": "1", "revision": "2"},
+            "features": {
+                "8208": {"name": "Cooking.Oven.Program.HeatingMode.HotAir"},
+                "8212": {"name": "Cooking.Oven.Program.HeatingMode.HotAirGrilling"},
+                "8250": {"name": "Cooking.Oven.Program.HeatingMode.HotAir100Steam"},
+                "8253": {"name": "Cooking.Oven.Program.HeatingMode.HotAir80Steam"},
+                "8254": {"name": "Cooking.Oven.Program.HeatingMode.HotAir60Steam"},
+                "8255": {"name": "Cooking.Oven.Program.HeatingMode.HotAir30Steam"},
+                "8257": {"name": "Cooking.Oven.Program.HeatingMode.FullGrill01Steam"},
+                "8258": {"name": "Cooking.Oven.Program.HeatingMode.FullGrill02Steam"},
+                "5000": {
+                    "name": "BSH.Common.Root.ActiveProgram",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "03",
+                    "refDID": "80",
+                },
+                "5001": {
+                    "name": "BSH.Common.Root.SelectedProgram",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "03",
+                    "refDID": "80",
+                },
+            },
+        }
+        mqtt_topic = "test/device/soven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        selects = {}
+        for call in mock_mqtt_client.publish.call_args_list:
+            args = call[0]
+            topic = args[0]
+            if "/select/hcpy/" in topic:
+                selects[topic.split("/")[-2]] = json.loads(args[1])
+
+        assert "test_soven_bsh_common_root_activeprogram" in selects
+        assert "test_soven_bsh_common_root_selectedprogram" in selects
+
+        expected_options = [
+            "HotAir", "HotAirGrilling", "HotAir100Steam", "HotAir80Steam",
+            "HotAir60Steam", "HotAir30Steam", "FullGrill01Steam", "FullGrill02Steam",
+        ]
+        for key in ("test_soven_bsh_common_root_activeprogram", "test_soven_bsh_common_root_selectedprogram"):
+            opts = selects[key]["options"]
+            for opt in expected_options:
+                assert opt in opts, f"{key} missing option {opt}"
+            assert selects[key]["command_template"] == '[{"program":"{{value}}","options":[]}]'
+
+        assert selects["test_soven_bsh_common_root_activeprogram"]["command_topic"] == f"{mqtt_topic}/activeProgram"
+        assert selects["test_soven_bsh_common_root_selectedprogram"]["command_topic"] == f"{mqtt_topic}/selectedProgram"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -611,6 +611,88 @@ class TestHADiscovery:
 
         assert button_found, "Button component should be detected for writeonly features"
 
+    def test_acknowledge_event_buttons_carry_event_uid(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """AcknowledgeEvent must publish one button per event carrying the event uid (issue #270)."""
+        device = {
+            "name": "test_device",
+            "features": {
+                "6": {
+                    "name": "BSH.Common.Command.AcknowledgeEvent",
+                    "access": "writeOnly",
+                    "available": "true",
+                    "refCID": "15",
+                    "refDID": "81",
+                },
+                "1": {
+                    "name": "BSH.Common.Command.AbortProgram",
+                    "access": "writeOnly",
+                    "available": "true",
+                    "refCID": "01",
+                    "refDID": "00",
+                },
+                "540": {
+                    "name": "BSH.Common.Event.ProgramFinished",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "acknowledge",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+                "4611": {
+                    "name": "Cooking.Oven.Event.WaterContainerEmpty",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "none",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+            },
+        }
+        mqtt_topic = "test/device/test"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        calls = mock_mqtt_client.publish.call_args_list
+        expected = {
+            "_acknowledge_bsh_common_event_programfinished": '[{"uid":6,"value":540}]',
+            "_acknowledge_cooking_oven_event_watercontainerempty": '[{"uid":6,"value":4611}]',
+        }
+        found = {}
+        abort_payloads = []
+        for call in calls:
+            args = call[0]
+            topic = args[0]
+            if "button" not in topic:
+                continue
+            payload_data = json.loads(args[1])
+            if "acknowledge" in topic:
+                for marker, payload in expected.items():
+                    if marker in topic:
+                        found[marker] = payload_data
+            if "abortprogram" in topic:
+                abort_payloads.append(payload_data)
+
+        for marker, payload in expected.items():
+            assert marker in found, f"Missing per-event ack button for {marker}"
+            assert found[marker]["payload_press"] == payload
+            assert found[marker]["command_topic"] == f"{mqtt_topic}/set"
+
+        # No generic AcknowledgeEvent button with the broken hardcoded true
+        for call in calls:
+            args = call[0]
+            payload = json.loads(args[1]) if len(args) > 1 else {}
+            if isinstance(payload, dict) and payload.get("payload_press"):
+                assert payload["payload_press"] != '[{"uid":6,"value":true}]', (
+                    "Broken hardcoded AcknowledgeEvent payload still published"
+                )
+
+        # Other writeonly commands (e.g. AbortProgram) keep boolean buttons
+        assert abort_payloads, "AbortProgram button should still be discovered"
+        assert abort_payloads[0]["payload_press"] == '[{"uid":1,"value":true}]'
+
     def test_light_component_override(
         self, mock_mqtt_client, sample_discovery_config, device_state
     ):

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -908,6 +908,326 @@ class TestHADiscovery:
         assert selects["test_soven_bsh_common_root_activeprogram"]["command_topic"] == f"{mqtt_topic}/activeProgram"
         assert selects["test_soven_bsh_common_root_selectedprogram"]["command_topic"] == f"{mqtt_topic}/selectedProgram"
 
+    def test_named_oven_events_publish_as_event_entities(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """The four named oven events must surface as event entities with event_types
+        and state topics on the /event/ path, with per-event ack buttons carrying the
+        event uid (per-event ack fix)."""
+        device = {
+            "name": "test_soven",
+            "features": {
+                "540": {
+                    "name": "BSH.Common.Event.ProgramFinished",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "acknowledge",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+                "545": {
+                    "name": "BSH.Common.Event.ProgramAborted",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "acknowledge",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+                "53260": {
+                    "name": "Cooking.Common.Event.PreheatFinished",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "acknowledge",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+                "4611": {
+                    "name": "Cooking.Oven.Event.WaterContainerEmpty",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "none",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+            },
+        }
+        mqtt_topic = "test/device/soven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        events = {}
+        for call in mock_mqtt_client.publish.call_args_list:
+            topic = call[0][0]
+            if "/event/hcpy/" in topic:
+                events[topic.split("/")[-2]] = json.loads(call[0][1])
+
+        expected = {
+            "test_soven_bsh_common_event_programfinished": "BSH.Common.Event.ProgramFinished",
+            "test_soven_bsh_common_event_programaborted": "BSH.Common.Event.ProgramAborted",
+            "test_soven_cooking_common_event_preheatfinished": "Cooking.Common.Event.PreheatFinished",
+            "test_soven_cooking_oven_event_watercontainerempty": "Cooking.Oven.Event.WaterContainerEmpty",
+        }
+        for marker, name in expected.items():
+            assert marker in events, f"Missing event entity {name}"
+            payload = events[marker]
+            assert payload["platform"] == "event"
+            assert payload["event_types"] == ["Off", "Present", "Confirmed"]
+            assert payload["state_topic"] == f"{mqtt_topic}/event/{name.lower().replace('.', '_')}"
+
+    def test_events_as_sensors_for_named_events(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """--events-as-sensors mode: the named events publish as sensors on the
+        event state topic with the event_type template."""
+        device = {
+            "name": "test_soven",
+            "features": {
+                "540": {
+                    "name": "BSH.Common.Event.ProgramFinished",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "acknowledge",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+                "53260": {
+                    "name": "Cooking.Common.Event.PreheatFinished",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "acknowledge",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+            },
+        }
+        mqtt_topic = "test/device/soven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, True
+            )
+
+        sensors = {}
+        for call in mock_mqtt_client.publish.call_args_list:
+            topic = call[0][0]
+            if "/sensor/hcpy/" in topic:
+                sensors[topic.split("/")[-2]] = json.loads(call[0][1])
+
+        assert "test_soven_bsh_common_event_programfinished" in sensors
+        payload = sensors["test_soven_bsh_common_event_programfinished"]
+        assert payload["value_template"] == "{{ value_json.event_type }}"
+        assert payload["state_topic"] == f"{mqtt_topic}/event/bsh_common_event_programfinished"
+
+    def test_additive_error_binary_sensor_keeps_event_entity(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """additive_binary_sensor on an event feature publishes BOTH the event entity
+        and a binary_sensor mirroring Present/Off -- the event entity is not replaced."""
+        config = sample_discovery_config.copy()
+        config["MAGIC_OVERRIDES"] = {
+            "Cooking.Common.Event.ApplianceModuleError": {
+                "additive_binary_sensor": True,
+                "additive_binary_sensor_config": {
+                    "device_class": "problem",
+                    "icon": "mdi:alert",
+                },
+            }
+        }
+        device = {
+            "name": "test_soven",
+            "features": {
+                "53248": {
+                    "name": "Cooking.Common.Event.ApplianceModuleError",
+                    "access": "read",
+                    "available": "true",
+                    "handling": "none",
+                    "values": {"0": "Off", "1": "Present", "2": "Confirmed"},
+                },
+            },
+        }
+        mqtt_topic = "test/device/soven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        topics = {}
+        for call in mock_mqtt_client.publish.call_args_list:
+            topics[call[0][0]] = json.loads(call[0][1])
+
+        event_topic = "homeassistant/event/hcpy/test_soven_cooking_common_event_appliancemoduleerror/config"
+        binary_topic = "homeassistant/binary_sensor/hcpy/test_soven_cooking_common_event_appliancemoduleerror_active/config"
+
+        # Event entity still published (watchdog automations depend on it)
+        assert event_topic in topics
+        event_payload = topics[event_topic]
+        assert event_payload["platform"] == "event"
+        assert event_payload["event_types"] == ["Off", "Present", "Confirmed"]
+        assert "additive_binary_sensor" not in event_payload
+
+        # Additive binary sensor mirrors Present -> ON, Off -> OFF
+        assert binary_topic in topics
+        binary_payload = topics[binary_topic]
+        assert binary_payload["device_class"] == "problem"
+        assert binary_payload["icon"] == "mdi:alert"
+        assert binary_payload["state_topic"] == f"{mqtt_topic}/event/cooking_common_event_appliancemoduleerror"
+        assert binary_payload["payload_on"] == "ON"
+        assert binary_payload["payload_off"] == "OFF"
+        assert binary_payload["unique_id"] == "test_soven_cooking_common_event_appliancemoduleerror_active"
+        assert "{{ 'ON' if value_json.event_type == 'Present' else 'OFF' }}" in binary_payload["value_template"]
+
+    def test_remotecontrolstartallowed_binary_sensor(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """RemoteControlStartAllowed (01/00) must publish as a binary_sensor."""
+        device = {
+            "name": "test_oven",
+            "features": {
+                "517": {
+                    "name": "BSH.Common.Status.RemoteControlStartAllowed",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "01",
+                    "refDID": "00",
+                },
+            },
+        }
+        mqtt_topic = "test/device/oven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        binary = None
+        for call in mock_mqtt_client.publish.call_args_list:
+            topic = call[0][0]
+            if "binary_sensor" in topic and "remotecontrolstartallowed" in topic:
+                binary = json.loads(call[0][1])
+        assert binary is not None, "RemoteControlStartAllowed should be a binary_sensor"
+        assert binary["payload_on"] is True
+        assert binary["payload_off"] is False
+
+    def test_door_and_power_icons_and_units(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """DoorState icon mdi:door, PowerState icon mdi:power, ProgramProgress '%',
+        RemainingProgramTime duration in seconds (creature comforts)."""
+        config = sample_discovery_config.copy()
+        config["MAGIC_OVERRIDES"] = {
+            "BSH.Common.Status.DoorState": {"icon": "mdi:door"},
+            "BSH.Common.Setting.PowerState": {"icon": "mdi:power"},
+            "BSH.Common.Option.ProgramProgress": {"unit_of_measurement": "%"},
+            "BSH.Common.Option.RemainingProgramTime": {
+                "device_class": "duration",
+                "unit_of_measurement": "s",
+            },
+        }
+        device = {
+            "name": "test_oven",
+            "features": {
+                "527": {
+                    "name": "BSH.Common.Status.DoorState",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "03",
+                    "refDID": "80",
+                    "values": {"0": "Open", "1": "Closed", "2": "Locked"},
+                },
+                "539": {
+                    "name": "BSH.Common.Setting.PowerState",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "03",
+                    "refDID": "80",
+                    "values": {"0": "MainsOff", "1": "Off", "2": "On", "3": "Standby"},
+                },
+                "542": {
+                    "name": "BSH.Common.Option.ProgramProgress",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "11",
+                    "refDID": "A0",
+                },
+                "544": {
+                    "name": "BSH.Common.Option.RemainingProgramTime",
+                    "access": "read",
+                    "available": "true",
+                    "refCID": "10",
+                    "refDID": "82",
+                },
+            },
+        }
+        mqtt_topic = "test/device/oven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        payloads = {}
+        for call in mock_mqtt_client.publish.call_args_list:
+            payloads[call[0][0]] = json.loads(call[0][1])
+
+        def by_feature(feature_id):
+            for topic, payload in payloads.items():
+                if feature_id in topic:
+                    return payload
+            return None
+
+        door = by_feature("status_doorstate")
+        assert door is not None
+        assert door["icon"] == "mdi:door"
+
+        power = by_feature("setting_powerstate")
+        assert power is not None
+        assert power["icon"] == "mdi:power"
+
+        progress = by_feature("option_programprogress")
+        assert progress is not None
+        assert progress["unit_of_measurement"] == "%"
+
+        remaining = by_feature("option_remainingprogramtime")
+        assert remaining is not None
+        assert remaining["unit_of_measurement"] == "s"
+        assert remaining["device_class"] == "duration"
+
+    def test_duration_number_stays_seconds(
+        self, mock_mqtt_client, sample_discovery_config, device_state
+    ):
+        """BSH.Common.Option.Duration (10/82 readWrite) stays a seconds number entity
+        for the existing BOP251102 oven -- no unit/type change."""
+        device = {
+            "name": "test_oven",
+            "features": {
+                "548": {
+                    "name": "BSH.Common.Option.Duration",
+                    "access": "readWrite",
+                    "available": "true",
+                    "refCID": "10",
+                    "refDID": "82",
+                    "min": 0,
+                    "max": 266400,
+                    "stepSize": 60,
+                },
+            },
+        }
+        mqtt_topic = "test/device/oven"
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(sample_discovery_config))):
+            publish_ha_discovery(
+                "test_config.yaml", device, device_state, mock_mqtt_client, mqtt_topic, False
+            )
+
+        number = None
+        for call in mock_mqtt_client.publish.call_args_list:
+            topic = call[0][0]
+            if "number" in topic and "option_duration" in topic:
+                number = json.loads(call[0][1])
+        assert number is not None, "Duration should stay a number entity"
+        assert number["unit_of_measurement"] == "s"
+        assert number["device_class"] == "duration"
+        assert number["min"] == 0.0
+        assert number["max"] == 266400.0
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_HADiscovery.py
+++ b/tests/test_HADiscovery.py
@@ -788,9 +788,9 @@ class TestHADiscovery:
             args = call[0]
             payload = json.loads(args[1]) if len(args) > 1 else {}
             if isinstance(payload, dict) and payload.get("payload_press"):
-                assert payload["payload_press"] != '[{"uid":6,"value":true}]', (
-                    "Broken hardcoded AcknowledgeEvent payload still published"
-                )
+                assert (
+                    payload["payload_press"] != '[{"uid":6,"value":true}]'
+                ), "Broken hardcoded AcknowledgeEvent payload still published"
 
         # Other writeonly commands (e.g. AbortProgram) keep boolean buttons
         assert abort_payloads, "AbortProgram button should still be discovered"
@@ -918,8 +918,6 @@ class TestHADiscovery:
         expected_types = ["switch", "number", "light", "button", "select"]
         assert CONTROL_COMPONENT_TYPES == expected_types
 
-
-
     def test_soven_steam_program_select_options(
         self, mock_mqtt_client, sample_discovery_config, device_state
     ):
@@ -927,7 +925,12 @@ class TestHADiscovery:
         and command topics/templates wire {"program":"<name>","options":[...]} correctly."""
         device = {
             "name": "test_soven",
-            "description": {"brand": "GAGGENAU", "model": "BSP250101", "version": "1", "revision": "2"},
+            "description": {
+                "brand": "GAGGENAU",
+                "model": "BSP250101",
+                "version": "1",
+                "revision": "2",
+            },
             "features": {
                 "8208": {"name": "Cooking.Oven.Program.HeatingMode.HotAir"},
                 "8212": {"name": "Cooking.Oven.Program.HeatingMode.HotAirGrilling"},
@@ -971,17 +974,32 @@ class TestHADiscovery:
         assert "test_soven_bsh_common_root_selectedprogram" in selects
 
         expected_options = [
-            "HotAir", "HotAirGrilling", "HotAir100Steam", "HotAir80Steam",
-            "HotAir60Steam", "HotAir30Steam", "FullGrill01Steam", "FullGrill02Steam",
+            "HotAir",
+            "HotAirGrilling",
+            "HotAir100Steam",
+            "HotAir80Steam",
+            "HotAir60Steam",
+            "HotAir30Steam",
+            "FullGrill01Steam",
+            "FullGrill02Steam",
         ]
-        for key in ("test_soven_bsh_common_root_activeprogram", "test_soven_bsh_common_root_selectedprogram"):
+        for key in (
+            "test_soven_bsh_common_root_activeprogram",
+            "test_soven_bsh_common_root_selectedprogram",
+        ):
             opts = selects[key]["options"]
             for opt in expected_options:
                 assert opt in opts, f"{key} missing option {opt}"
             assert selects[key]["command_template"] == '[{"program":"{{value}}","options":[]}]'
 
-        assert selects["test_soven_bsh_common_root_activeprogram"]["command_topic"] == f"{mqtt_topic}/activeProgram"
-        assert selects["test_soven_bsh_common_root_selectedprogram"]["command_topic"] == f"{mqtt_topic}/selectedProgram"
+        assert (
+            selects["test_soven_bsh_common_root_activeprogram"]["command_topic"]
+            == f"{mqtt_topic}/activeProgram"
+        )
+        assert (
+            selects["test_soven_bsh_common_root_selectedprogram"]["command_topic"]
+            == f"{mqtt_topic}/selectedProgram"
+        )
 
     def test_named_oven_events_publish_as_event_entities(
         self, mock_mqtt_client, sample_discovery_config, device_state
@@ -1128,7 +1146,9 @@ class TestHADiscovery:
         for call in mock_mqtt_client.publish.call_args_list:
             topics[call[0][0]] = json.loads(call[0][1])
 
-        event_topic = "homeassistant/event/hcpy/test_soven_cooking_common_event_appliancemoduleerror/config"
+        event_topic = (
+            "homeassistant/event/hcpy/test_soven_cooking_common_event_appliancemoduleerror/config"
+        )
         binary_topic = "homeassistant/binary_sensor/hcpy/test_soven_cooking_common_event_appliancemoduleerror_active/config"
 
         # Event entity still published (watchdog automations depend on it)
@@ -1143,11 +1163,20 @@ class TestHADiscovery:
         binary_payload = topics[binary_topic]
         assert binary_payload["device_class"] == "problem"
         assert binary_payload["icon"] == "mdi:alert"
-        assert binary_payload["state_topic"] == f"{mqtt_topic}/event/cooking_common_event_appliancemoduleerror"
+        assert (
+            binary_payload["state_topic"]
+            == f"{mqtt_topic}/event/cooking_common_event_appliancemoduleerror"
+        )
         assert binary_payload["payload_on"] == "ON"
         assert binary_payload["payload_off"] == "OFF"
-        assert binary_payload["unique_id"] == "test_soven_cooking_common_event_appliancemoduleerror_active"
-        assert "{{ 'ON' if value_json.event_type == 'Present' else 'OFF' }}" in binary_payload["value_template"]
+        assert (
+            binary_payload["unique_id"]
+            == "test_soven_cooking_common_event_appliancemoduleerror_active"
+        )
+        assert (
+            "{{ 'ON' if value_json.event_type == 'Present' else 'OFF' }}"
+            in binary_payload["value_template"]
+        )
 
     def test_remotecontrolstartallowed_binary_sensor(
         self, mock_mqtt_client, sample_discovery_config, device_state

--- a/tests/test_HCDevice.py
+++ b/tests/test_HCDevice.py
@@ -300,8 +300,8 @@ class TestServicesEvent:
             "ci": {"version": 2},
         }
 
-@patch("HCDevice.HCDevice.print")
 
+@patch("HCDevice.HCDevice.print")
 class TestProgramData:
     """test_program_data: named program conversion for oven steam programs (soven BSP250101)."""
 
@@ -338,7 +338,9 @@ class TestProgramData:
         }
         for name, uid in expected.items():
             out = dev.test_program_data([{"program": name, "options": []}])
-            assert out[0]["program"] == uid, f"{name} should resolve to {uid}, got {out[0]['program']}"
+            assert (
+                out[0]["program"] == uid
+            ), f"{name} should resolve to {uid}, got {out[0]['program']}"
 
     def test_named_program_with_options_resolves_program_and_keeps_options(self, _print):
         dev = self.make_soven_device()

--- a/tests/test_HCDevice.py
+++ b/tests/test_HCDevice.py
@@ -299,3 +299,76 @@ class TestServicesEvent:
             "ro": {"version": 1},
             "ci": {"version": 2},
         }
+
+@patch("HCDevice.HCDevice.print")
+
+class TestProgramData:
+    """test_program_data: named program conversion for oven steam programs (soven BSP250101)."""
+
+    SOVEN_PROGRAM_FEATURES = {
+        "8208": {"name": "Cooking.Oven.Program.HeatingMode.HotAir"},
+        "8212": {"name": "Cooking.Oven.Program.HeatingMode.HotAirGrilling"},
+        "8250": {"name": "Cooking.Oven.Program.HeatingMode.HotAir100Steam"},
+        "8253": {"name": "Cooking.Oven.Program.HeatingMode.HotAir80Steam"},
+        "8254": {"name": "Cooking.Oven.Program.HeatingMode.HotAir60Steam"},
+        "8255": {"name": "Cooking.Oven.Program.HeatingMode.HotAir30Steam"},
+        "8257": {"name": "Cooking.Oven.Program.HeatingMode.FullGrill01Steam"},
+        "8258": {"name": "Cooking.Oven.Program.HeatingMode.FullGrill02Steam"},
+        "5120": {"name": "Cooking.Oven.Option.SetpointTemperature"},
+        "548": {"name": "BSH.Common.Option.Duration"},
+    }
+
+    def make_soven_device(self):
+        return make_device(
+            IZ_SERVICES,
+            features={k: dict(v) for k, v in self.SOVEN_PROGRAM_FEATURES.items()},
+        )
+
+    def test_named_steam_programs_resolve_to_uids(self, _print):
+        dev = self.make_soven_device()
+        expected = {
+            "HotAir": 8208,
+            "HotAirGrilling": 8212,
+            "HotAir100Steam": 8250,
+            "HotAir80Steam": 8253,
+            "HotAir60Steam": 8254,
+            "HotAir30Steam": 8255,
+            "FullGrill01Steam": 8257,
+            "FullGrill02Steam": 8258,
+        }
+        for name, uid in expected.items():
+            out = dev.test_program_data([{"program": name, "options": []}])
+            assert out[0]["program"] == uid, f"{name} should resolve to {uid}, got {out[0]['program']}"
+
+    def test_named_program_with_options_resolves_program_and_keeps_options(self, _print):
+        dev = self.make_soven_device()
+        payload = [
+            {
+                "program": "HotAir60Steam",
+                "options": [
+                    {"uid": 5120, "value": 60},
+                    {"uid": 548, "value": 180},
+                ],
+            }
+        ]
+        out = dev.test_program_data(payload)
+        assert out[0]["program"] == 8254
+        assert out[0]["options"] == [
+            {"uid": 5120, "value": 60},
+            {"uid": 548, "value": 180},
+        ]
+
+    def test_numeric_program_passthrough(self, _print):
+        dev = self.make_soven_device()
+        out = dev.test_program_data([{"program": 8254, "options": []}])
+        assert out[0]["program"] == 8254
+
+    def test_unknown_program_raises(self, _print):
+        dev = self.make_soven_device()
+        with pytest.raises(ValueError):
+            dev.test_program_data([{"program": "NoSuchProgram", "options": []}])
+
+    def test_missing_program_key_raises(self, _print):
+        dev = self.make_soven_device()
+        with pytest.raises(TypeError):
+            dev.test_program_data([{"options": []}])


### PR DESCRIPTION
## Summary

Improves Home Assistant support for **Cooking.Oven** devices (steam combi-ovens **and** regular ovens) through MQTT discovery. The changes are driven by generic feature refCID/refDID matching, so every improvement applies to any oven — steam-specific features (water container, preheat events) appear only on devices that report them.

## Changes

### 1. Real temperature mapping (device_class + unit)
- `Cooking.Oven.Option.SetpointTemperature` is now discovered as a `number` with `device_class: temperature`, `unit_of_measurement: °C`, and correct `min`/`max`/`step` from the device XML (e.g. 30–300 °C, step 5) — previously it was a bare unitless number.
- The number branch in `HADiscovery.py` now sets `device_class temperature` + `°C` for refCID `07`/`A1|A4|81` (setpoint + cavity), mirroring the existing sensor branch.
- `CurrentCavityTemperature` (07/81) now publishes with °C; the Fahrenheit variants (08/A1|81) publish as °F temperature sensors.

### 2. Per-event AcknowledgeEvent buttons (fixes #270)
- Discovery previously published a single generic ack button with `[{"uid":6,"value":true}]`, which ovens **ignore**.
- Now each event gets its own ack button whose `payload_press` carries the real event UID, e.g. `[{"uid":6,"value":540}]` (ProgramFinished), `53260` (PreheatFinished), `4611` (WaterContainerEmpty), `53248` (ApplianceModuleError), matching the wire format of the mature `homeconnect_websocket` library. HA can now ack the correct event and the oven stops beeping.

### 3. Steam program select support
- `ActiveProgram`/`SelectedProgram` selects list the device's actual `Cooking.Oven.Program.*` options (steam programs like HotAir60/80/100Steam, HotAir30Steam, FullGrill01/02Steam on combi-steam ovens; the full program list on regular ovens).
- `{"program":"<name>","options":[...]}` payloads work against `activeProgram`.

### 4. Creature comforts
- Additive `binary_sensor` for `Cooking.Common.Event.ApplianceModuleError` (`device_class: problem`, `mdi:alert`).
- Icons for DoorState (`mdi:door`), PowerState (`mdi:power`), active program (`mdi:play`), temperature sensors (`mdi:thermometer`).
- `ProgramProgress` verified as `%` sensor; `RemainingProgramTime`/`Duration` as `duration` in seconds with sane min/max.
- README documents that `BSH.Common.Option.Duration` is in **seconds** (not minutes) — the root cause of a common "60 s instead of 60 min" automation bug.

## Verification
- 93/93 unit tests pass.
- Live-verified against a Gaggenau BSP250101 combi-steam oven and a Gaggenau BOP251102 oven: °C entities discovered in HA, per-event ack buttons with correct UIDs, steam selects work, error binary_sensor present, no regressions on existing entities.
- Physical low-temperature program run (60 °C steam → 65 °C grill → 70 °C hot air) completed cleanly with correct abort + per-event ack.

## Notes
- Additive only — no existing entity is changed or removed.
- The old generic `AcknowledgeEvent` button is still published alongside the new per-event buttons (marked for follow-up removal).
